### PR TITLE
fix: 如果已经设置showTime,会被判断覆盖

### DIFF
--- a/packages/form-render/src/components/dateHoc.jsx
+++ b/packages/form-render/src/components/dateHoc.jsx
@@ -34,8 +34,8 @@ export default (p, onChange, DateComponent) => {
     onChange,
   };
 
-  // TODO: format是在options里自定义的情况，是否要判断一下要不要showTime
-  if (format === 'dateTime') {
+  // fix format类型为dateTime且showTime无值时，设置默认showTime值为true
+  if (format === 'dateTime' && !p.options.showTime) {
     dateParams.showTime = true;
   }
 


### PR DESCRIPTION
假如已经在设置showTime具体配置的情况下，先前的代码会直接将showTime 改为true，丢失自定义的配置，比如 showTime: { defaultValue: '11:20:00' }