### PR TITLE
修复 Schema Field 的 type 不合法时渲染 crash 的问题

### DIFF
--- a/packages/form-render/src/core/RenderField/ExtendedWidget.js
+++ b/packages/form-render/src/core/RenderField/ExtendedWidget.js
@@ -44,6 +44,11 @@ const ExtendedWidget = ({
     widgetName = 'html';
   }
   const Widget = widgets[widgetName];
+  if (!Widget) {
+    console.error(`不合法的 schema field type: "${widgetName}"`);
+    return null;
+  }
+
   const extraSchema = extraSchemaList[widgetName];
 
   let widgetProps = {


### PR DESCRIPTION
修复 Schema Field 的 type 不合法时渲染 crash 的问题
![image](https://user-images.githubusercontent.com/23466520/115890341-6b241880-a487-11eb-807d-b9db30accdde.png)
