### PR TITLE
feat: 期望组件能够拿到 form 实例

### DIFF
--- a/packages/form-render/package.json
+++ b/packages/form-render/package.json
@@ -1,6 +1,6 @@
 {
   "name": "form-render",
-  "version": "1.5.3-alpha.1",
+  "version": "1.5.2",
   "description": "通过 JSON Schema 生成标准 Form，常用于自定义搭建配置界面生成",
   "repository": {
     "type": "git",

--- a/packages/form-render/package.json
+++ b/packages/form-render/package.json
@@ -1,6 +1,6 @@
 {
   "name": "form-render",
-  "version": "1.5.2",
+  "version": "1.5.3-alpha.1",
   "description": "通过 JSON Schema 生成标准 Form，常用于自定义搭建配置界面生成",
   "repository": {
     "type": "git",

--- a/packages/form-render/src/core/RenderField/ExtendedWidget.js
+++ b/packages/form-render/src/core/RenderField/ExtendedWidget.js
@@ -27,7 +27,7 @@ const ExtendedWidget = ({
   disabled,
   dataIndex,
 }) => {
-  const { widgets, mapping } = useTools();
+  const { widgets, mapping, _form } = useTools();
 
   // TODO1: 需要查一下卡顿的源头
   // if (isObjType(schema)) {
@@ -59,6 +59,7 @@ const ExtendedWidget = ({
   const extraSchema = extraSchemaList[widgetName];
 
   let widgetProps = {
+    _form,
     schema: { ...schema, ...extraSchema },
     onChange,
     value,
@@ -99,6 +100,8 @@ const ExtendedWidget = ({
   };
 
   const finalProps = transformProps(widgetProps);
+
+  console.log('===> finalProps', finalProps)
 
   return (
     <Suspense fallback={<div></div>}>

--- a/packages/form-render/src/core/RenderField/ExtendedWidget.js
+++ b/packages/form-render/src/core/RenderField/ExtendedWidget.js
@@ -101,8 +101,6 @@ const ExtendedWidget = ({
 
   const finalProps = transformProps(widgetProps);
 
-  console.log('===> finalProps', finalProps)
-
   return (
     <Suspense fallback={<div></div>}>
       <Widget {...finalProps} />

--- a/packages/form-render/src/core/RenderField/ExtendedWidget.js
+++ b/packages/form-render/src/core/RenderField/ExtendedWidget.js
@@ -59,7 +59,6 @@ const ExtendedWidget = ({
   const extraSchema = extraSchemaList[widgetName];
 
   let widgetProps = {
-    _form,
     schema: { ...schema, ...extraSchema },
     onChange,
     value,
@@ -97,6 +96,9 @@ const ExtendedWidget = ({
     formData,
     dataPath,
     dataIndex,
+    setErrorFields: _form.setErrorFields,
+    removeErrorField: _form.removeErrorField,
+    setSchemaByPath: _form.setSchemaByPath,
   };
 
   const finalProps = transformProps(widgetProps);

--- a/packages/form-render/src/index.js
+++ b/packages/form-render/src/index.js
@@ -151,6 +151,7 @@ function App({
 
   const tools = useMemo(
     () => ({
+      _form: form,
       widgets: { ...defaultWidgets, ...widgets },
       mapping: { ...defaultMapping, ...mapping },
       onValuesChange,


### PR DESCRIPTION
场景：上传控件在上传后会进行校验，校验不通过会通过 error 的方式显示错误信息，我想用 form.setErrorFields 来实现，但是组件中拿不到当前 form 的实例，因此期望能够在增强 widget props，在组件中能够拿到当前的 form 实例