### PR TITLE
fix: make children optional

### DIFF
--- a/packages/table-render/src/index.tsx
+++ b/packages/table-render/src/index.tsx
@@ -171,7 +171,7 @@ const Container = (props, ref) => {
 
 const TableProvider = forwardRef(Container);
 
-const withTable = Component => ({ children, ...rest }) => {
+const withTable = Component => ({ children = undefined, ...rest }) => {
   return (
     <TableProvider {...rest}>
       <Component />


### PR DESCRIPTION
修复 withTable TypeScript 不传递 children 报错， 信息如下：
```

Failed to compile
/Users/xxx/workspace/try-x-render/src/App.tsx
TypeScript error in /Users/xxx/workspace/try-x-render/src/App.tsx(16,8):
Property 'children' is missing in type '{}' but required in type '{ [x: string]: any; children: any; }'.  TS2741

    14 |   return (
    15 |     <div>
  > 16 |       <DataList />
       |        ^
    17 |     </div>
    18 |   );
    19 | }
```

其中
DataList = withTable(MyComponent)