### PR TITLE
fix: change mapping config `'string:time': 'time'` to `'string:time': 'date'`

### DIFF
--- a/packages/form-render/src/mapping.js
+++ b/packages/form-render/src/mapping.js
@@ -15,7 +15,7 @@ export const mapping = {
   'string:month': 'date',
   'string:week': 'date',
   'string:quarter': 'date',
-  'string:time': 'time',
+  'string:time': 'date',
   'string:textarea': 'textarea',
   'string:color': 'color',
   'string:image': 'imageInput',


### PR DESCRIPTION
修复编辑器时间组件配置面板空白问题