### PR TITLE
fix: global setting lost value

### DIFF
--- a/tools/schema-generator/src/components/Settings/GlobalSettings.jsx
+++ b/tools/schema-generator/src/components/Settings/GlobalSettings.jsx
@@ -10,9 +10,11 @@ export default function GlobalSettings({ widgets }) {
   const setGlobal = useGlobal();
   const globalSettings = userProps.globalSettings || defaultGlobalSettings;
 
-  const onDataChange = value => {
+  const onDataChange = (value = {}) => {
     setInnerUpdate(!!Object.keys(value).length);
-    setGlobal({ frProps: value });
+    if (Object.keys(value).length > 0) {
+      setGlobal({ frProps: value });
+    }
   };
 
   useEffect(() => {


### PR DESCRIPTION
问题

![image](https://user-images.githubusercontent.com/546535/143844229-cb192fd5-d391-47f9-87c2-e0fe011b02a8.png)
![image](https://user-images.githubusercontent.com/546535/143844280-19f6c688-6343-49fa-ad31-084fee370c0b.png)

就是如果设置了 表单配置后， 如果在选中组件， 在到组件焦点丢失， 这个表单配置就会丢失。

debug 后发现是这里 onDataChange 触发的时候， 会有一个空对象进来， 导致了，这里的表单配置内容被清空了。

不确定这个改法是不是最优， 但是可以解决问题