### PR TITLE
feat: 新增 resetFormFields 方法

### DIFF
--- a/packages/form-render/src/form-render-core/src/useForm.js
+++ b/packages/form-render/src/form-render-core/src/useForm.js
@@ -2,7 +2,7 @@
 import { useEffect, useRef, useMemo, useState } from 'react';
 import { validateAll } from './validator';
 import { useSet } from './hooks';
-import { set, sortedUniqBy } from 'lodash-es';
+import { get, set, sortedUniqBy } from 'lodash-es';
 import { processData, transformDataWithBind2 } from './processData';
 import {
   generateDataSkeleton,
@@ -370,20 +370,13 @@ const useForm = props => {
   };
 
   const resetFields = (options) => {
-    if (typeof options === 'undefined') {
-      setState({
-        formData: {},
-        submitData: [],
-        errorFields: [],
-        touchedKeys: [],
-        allTouched: false,
-      });
-    } else {
-      // 支持重置时自定义参数
-      if (options && typeof options === 'object') {
-        setState(options)
-      }
-    }
+    setState({
+      formData: options?.formData || {},
+      submitData: options?.submitData || [],
+      errorFields: options?.errorFields || [],
+      touchedKeys: options?.touchedKeys || [],
+      allTouched: options?.allTouched || false,
+    });
   };
 
   const endValidating = () =>

--- a/packages/form-render/src/form-render-core/src/useForm.js
+++ b/packages/form-render/src/form-render-core/src/useForm.js
@@ -372,7 +372,7 @@ const useForm = props => {
   const resetFields = (options) => {
     setState({
       formData: options?.formData || {},
-      submitData: options?.submitData || [],
+      submitData: options?.submitData || {},
       errorFields: options?.errorFields || [],
       touchedKeys: options?.touchedKeys || [],
       allTouched: options?.allTouched || false,

--- a/packages/form-render/src/form-render-core/src/useForm.js
+++ b/packages/form-render/src/form-render-core/src/useForm.js
@@ -379,6 +379,25 @@ const useForm = props => {
     });
   };
 
+  // 在不清空 formData 的情况下清空表单数据，这样可以在某些场景下避免抖动
+  const resetFormFields = ({
+    formData = {},
+    submitData = {},
+    errorFields = [],
+    touchedKeys = [],
+    allTouched = false,
+    ...rest,
+  } = {}) => {
+    setState({
+      formData,
+      submitData,
+      errorFields,
+      touchedKeys,
+      allTouched,
+      ...rest,
+    });
+  };
+
   const endValidating = () =>
     setState({
       isValidating: false,
@@ -412,6 +431,7 @@ const useForm = props => {
     setValues,
     getValues,
     resetFields,
+    resetFormFields,
     submit,
     init: submit, // 简版的迁移方案里用，正常用不到，换个名字迁移的时候大家更好接受点
     submitData,

--- a/packages/form-render/src/form-render-core/src/useForm.js
+++ b/packages/form-render/src/form-render-core/src/useForm.js
@@ -2,7 +2,7 @@
 import { useEffect, useRef, useMemo, useState } from 'react';
 import { validateAll } from './validator';
 import { useSet } from './hooks';
-import { get, set, sortedUniqBy } from 'lodash-es';
+import { set, sortedUniqBy } from 'lodash-es';
 import { processData, transformDataWithBind2 } from './processData';
 import {
   generateDataSkeleton,

--- a/packages/form-render/src/form-render-core/src/useForm.js
+++ b/packages/form-render/src/form-render-core/src/useForm.js
@@ -369,33 +369,21 @@ const useForm = props => {
       });
   };
 
-  const resetFields = () => {
-    setState({
-      formData: {},
-      submitData: {},
-      errorFields: [],
-      touchedKeys: [],
-      allTouched: false,
-    });
-  };
-
-  // 在不清空 formData 的情况下清空表单数据，这样可以在某些场景下避免抖动
-  const resetFormFields = ({
-    formData = {},
-    submitData = {},
-    errorFields = [],
-    touchedKeys = [],
-    allTouched = false,
-    ...rest,
-  } = {}) => {
-    setState({
-      formData,
-      submitData,
-      errorFields,
-      touchedKeys,
-      allTouched,
-      ...rest,
-    });
+  const resetFields = (options) => {
+    if (typeof options === 'undefined') {
+      setState({
+        formData: {},
+        submitData: [],
+        errorFields: [],
+        touchedKeys: [],
+        allTouched: false,
+      });
+    } else {
+      // 支持重置时自定义参数
+      if (options && typeof options === 'object') {
+        setState(options)
+      }
+    }
   };
 
   const endValidating = () =>
@@ -431,7 +419,6 @@ const useForm = props => {
     setValues,
     getValues,
     resetFields,
-    resetFormFields,
     submit,
     init: submit, // 简版的迁移方案里用，正常用不到，换个名字迁移的时候大家更好接受点
     submitData,


### PR DESCRIPTION
feat: 新增 resetFormFields 方法

现有的 resetFields 方法是无脑进行清空，没法进行指定，比如只清空 errorFields 不清空 formData，这个新增的 resetFormFields 可以更加灵活