### PR TITLE
fix: 修复使用setSchemaByPath页面不触发更新

### DIFF
--- a/packages/form-render/src/form-render-core/src/useForm.js
+++ b/packages/form-render/src/form-render-core/src/useForm.js
@@ -10,6 +10,7 @@ import {
   clone,
   schemaContainsExpression,
   parseAllExpression,
+  isEmpty,
 } from './utils';
 
 const useForm = props => {
@@ -108,7 +109,12 @@ const useForm = props => {
 
   useEffect(() => {
     if (schemaRef.current) {
-      let newFlatten = clone(_flatten.current);
+      // 处理使用setSchemaByPath,使用的是旧flatten 页面不触发更新。
+      let newFlatten = clone(
+        isEmpty(_finalFlatten.current)
+          ? _flatten.current
+          : _finalFlatten.current
+      );
       if (firstMount) {
         _flatten.current = flattenSchema(schemaRef.current);
         setState({ firstMount: false });

--- a/packages/form-render/src/form-render-core/src/utils.js
+++ b/packages/form-render/src/form-render-core/src/utils.js
@@ -326,7 +326,7 @@ export function combineSchema(propsSchema = {}, uiSchema = {}) {
   return { ...propsSchema, ...topLevelUi, properties: newObj };
 }
 
-function isEmpty(obj) {
+export function isEmpty(obj) {
   return Object.keys(obj).length === 0;
 }
 


### PR DESCRIPTION
https://x-render.gitee.io/form-render/advanced/watch 第二个例子schema 的联动，简单输入框输入，radio没变化

```js
  const setSchemaByPath = (path, newSchema) => {
    if (!_finalFlatten.current[path]) {
      console.error(`path：'${path}' 不存在(form.setSchemaByPath)`);
      return;
    }
    const newFlatten = clone(_finalFlatten.current);

    try {
      const _newSchema =
        typeof newSchema === 'function'
          ? newSchema(newFlatten[path].schema)
          : newSchema;
      newFlatten[path].schema = { ...newFlatten[path].schema, ..._newSchema };
     // 这里赋值的是finalFlatten， useEffect里面拿到的还是是_flatten.current，没有同步
      setState({ finalFlatten: newFlatten });
      _finalFlatten.current = newFlatten;
    } catch (error) {
      console.error(error, 'setSchemaByPath');
    }
  };

```