### PR TITLE
 fix: 修复fr-generator表单配置选中切换时配置项被重置 

### DIFF
--- a/tools/schema-generator/src/components/Settings/GlobalSettings.jsx
+++ b/tools/schema-generator/src/components/Settings/GlobalSettings.jsx
@@ -6,9 +6,11 @@ import { useStore, useGlobal } from '../../utils/hooks';
 export default function GlobalSettings({ widgets }) {
   const form = useForm();
   const [innerUpdate, setInnerUpdate] = useState(false);
+  const [innerInit, setInnerInit] = useState(true)
   const { widgets: globalWidgets, frProps, userProps = {} } = useStore();
   const setGlobal = useGlobal();
   const globalSettings = userProps.globalSettings || defaultGlobalSettings;
+
 
   const onDataChange = value => {
     setInnerUpdate(!!Object.keys(value).length);
@@ -29,7 +31,10 @@ export default function GlobalSettings({ widgets }) {
         form={form}
         schema={globalSettings}
         watch={{
-          '#': v => onDataChange(v),
+          '#': v => {
+            if (innerInit) return setInnerInit(false)
+            onDataChange(v)
+          },
         }}
         widgets={{ ...globalWidgets, ...widgets }}
       />


### PR DESCRIPTION
![问题截图](https://appstore-codemao.oss-cn-hangzhou.aliyuncs.com/chrome-capture.gif)
切换组件是 fr-generator 的form配置项会被清空
原因：是因为组件切换无时 配置项tab变成了一个， 由于结构发生变化， 表单配置项tab会被从新mount 一下， 触发onchange导致数据被重置， 
解决方法， 在组件init阶段 不触发表单onchange 
@F-loat 