### PR TITLE
fix typo

### DIFF
--- a/docs/form-render/index.md
+++ b/docs/form-render/index.md
@@ -309,13 +309,13 @@ export default connectForm(Demo);
 | submit           | 触发提交流程，一般在提交按钮上使用                  | `() => void`                                                                                                     |
 | resetFields      | 清空表单（也会清空一些内置状态，例如校验）          | `({formData?: any, submitData?: any, errorFields?: Error[], touchedKeys?: any[], allTouched?: boolean}) => void` |
 | errorFields      | 表单校验错误的数组                                  | `array,[{name, error: []}]`                                                                                      |
-| setErrorFields   | 外部手动修改 errorFields 校验信息，用于外部校验回填 | `(error: Error | Error[]) => void`                                                                               |
+| setErrorFields   | 外部手动修改 errorFields 校验信息，用于外部校验回填 | <code>(error: Error &#124; Error[]) => void</code>                                                                               |
 | setValues        | 外部手动修改 formData，用于已填写的表单的数据回填   | `(formData: any) => void`                                                                                        |
 | setValueByPath   | 外部修改指定单个 field 的数据(原名 onItemChange)    | `(path: string, value: any) => void`                                                                             |
 | setSchemaByPath  | 指定路径修改 schema                                 | `(path: string, value: any) => void`                                                                             |
 | setSchema        | 指定**多个**路径修改 schema。注 1                   | `({ path1: value1, path2: value2 }) => void`                                                                     |
 | getValues        | 获取表单内部维护的数据 formData                     | `() => void`                                                                                                     |
-| schema           | 表单的 schema                                       | object                                                                                                           |
+| schema           | 表单的 schema                                       | `object`                                                                                                           |
 | touchedKeys      | 已经触碰过的 field 的数据路径                       | `string[]`                                                                                                       |
 | removeErrorField | 外部手动删除某一个 path 下所有的校验信息            | `(path: string) => void`                                                                                         |
 | formData         | 表单内部维护的数据，建议使用 getValues/setValues    | `object`                                                                                                         |


### PR DESCRIPTION
1. 修复文档中markdown 的table中的code使用了| 导致了解析错误，使用转义字符替代
2. 补全了一个未加code标志的字段