### PR TITLE
修改bug，issues标题：[BUG]这里会导致只提示初始错误，请尽快修复 #597，这里会把原来已经校验的消息带出去，现在直接使用新的…

### DIFF
--- a/packages/form-render/src/form-render-core/src/core/RenderField/index.js
+++ b/packages/form-render/src/form-render-core/src/core/RenderField/index.js
@@ -78,7 +78,7 @@ const RenderField = props => {
           name: sameNameItem.name,
           error:
             error1.length > 0 && error2.length > 0
-              ? [...error1, ...error2]
+              ? error2
               : [],
         };
       } else {
@@ -117,7 +117,7 @@ const RenderField = props => {
       },
     }).then(res => {
       _setErrors(errors => {
-        return removeDupErrors(res);
+        return removeDupErrors([...errors, ...res]);
       });
     });
   };


### PR DESCRIPTION
…校验信息覆盖，上次修改会把所有的错误覆盖，再次修改

上次修改直接将122行的return removeDupErrors([...errors, ...res]);修改为[res]，会导致所有错误信息丢失，现在修改removeDupErrors函数，当获取到已有的错误信息时，用最新的错误信息覆盖原来的错误信息，错误信息展示也是取第一条信息，所以应该把最新的错误信息覆盖旧有的