### PR TITLE
Fix: 修复 virtualList 的展示错位问题

### DIFF
--- a/packages/form-render/src/form-render-core/src/core/RenderChildren/RenderList/VirtualList.js
+++ b/packages/form-render/src/form-render-core/src/core/RenderChildren/RenderList/VirtualList.js
@@ -161,7 +161,7 @@ const VirtualList = ({
 
       <Table
         rowKey="index"
-        scroll={{ y: scrollY, x: 'max-content' }}
+        scroll={{ y: scrollY, x: "100%" }}
         components={vt}
         size="small"
         columns={columns}

--- a/packages/form-render/src/form-render-core/src/core/RenderChildren/RenderList/VirtualList.js
+++ b/packages/form-render/src/form-render-core/src/core/RenderChildren/RenderList/VirtualList.js
@@ -161,7 +161,7 @@ const VirtualList = ({
 
       <Table
         rowKey="index"
-        scroll={{ y: scrollY, x: "100%" }}
+        scroll={{ y: scrollY, x: '100%' }}
         components={vt}
         size="small"
         columns={columns}


### PR DESCRIPTION
因之前设置 x 为 max-content 时， 会根据子元素中最长的一个来决定此元素的宽度， 此时若子元素的长度不及父元素长度时会出现错位， 设置为 100% 则默认占满， 且超出时也可正常滑动