### PR TITLE
fix: cannot change list items schema

### DIFF
--- a/packages/form-render/src/form-render-core/src/useForm.js
+++ b/packages/form-render/src/form-render-core/src/useForm.js
@@ -9,6 +9,7 @@ import {
   generateDataSkeleton,
   parseAllExpression,
   schemaContainsExpression,
+  getSchemaFromFlatten
 } from './utils';
 import { validateAll } from './validator';
 
@@ -111,10 +112,14 @@ const useForm = props => {
 
   useEffect(() => {
     if (schemaRef.current && firstMount) {
-      const flatten = flattenSchema(schemaRef.current);
-      setState({ flatten, firstMount: false });
+      setState({ firstMount: false });
     }
   }, [JSON.stringify(schemaRef.current), firstMount]);
+
+  useEffect(() => {
+    const flatten = flattenSchema(schemaRef.current);
+    setState({ flatten });
+  }, [JSON.stringify(schemaRef.current)]);
 
   // 统一的处理expression
   useEffect(() => {
@@ -246,8 +251,8 @@ const useForm = props => {
           };
         }
       });
-      setState({ flatten: newFlatten });
-      _flatten.current = newFlatten;
+
+      schemaRef.current = getSchemaFromFlatten(newFlatten);
     } catch (error) {
       console.error(error, 'setSchema');
     }
@@ -266,8 +271,8 @@ const useForm = props => {
           ? newSchema(newFlatten[path].schema)
           : newSchema;
       newFlatten[path].schema = { ...newFlatten[path].schema, ..._newSchema };
-      setState({ flatten: newFlatten });
-      _flatten.current = newFlatten;
+
+      schemaRef.current = getSchemaFromFlatten(newFlatten);
     } catch (error) {
       console.error(error, 'setSchemaByPath');
     }

--- a/packages/form-render/src/form-render-core/src/utils.js
+++ b/packages/form-render/src/form-render-core/src/utils.js
@@ -163,7 +163,9 @@ export function getSchemaFromFlatten(flatten, path = '#') {
           schema.properties[key] = getSchemaFromFlatten(flatten, child);
         }
         if (isListType(schema)) {
-          schema.items.properties[key] = getSchemaFromFlatten(flatten, child);
+          if (schema.items.properties[key]) {
+            schema.items.properties[key] = getSchemaFromFlatten(flatten, child);
+          }
         }
       });
     }


### PR DESCRIPTION
修复 使用 `setSchema` 或者 `setSchemaByPath` 修改 TableList 中的 items 的 schema 无效的问题，具体可查看 [demo](https://codesandbox.io/s/hardcore-shadow-4j2gil?file=/App.jsx)