### PR TITLE
fix: cannot change list items schema

### DIFF
--- a/packages/form-render/src/form-render-core/src/useForm.js
+++ b/packages/form-render/src/form-render-core/src/useForm.js
@@ -9,6 +9,7 @@ import {
   generateDataSkeleton,
   parseAllExpression,
   schemaContainsExpression,
+  getSchemaFromFlatten
 } from './utils';
 import { validateAll } from './validator';
 
@@ -112,9 +113,14 @@ const useForm = props => {
   useEffect(() => {
     if (schemaRef.current && firstMount) {
       const flatten = flattenSchema(schemaRef.current);
-      setState({ flatten, firstMount: false });
+      setState({ firstMount: false });
     }
   }, [JSON.stringify(schemaRef.current), firstMount]);
+
+  useEffect(() => {
+    const flatten = flattenSchema(schemaRef.current);
+    setState({ flatten });
+  }, [JSON.stringify(schemaRef.current)]);
 
   // 统一的处理expression
   useEffect(() => {
@@ -246,8 +252,8 @@ const useForm = props => {
           };
         }
       });
-      setState({ flatten: newFlatten });
-      _flatten.current = newFlatten;
+
+      schemaRef.current = getSchemaFromFlatten(newFlatten);
     } catch (error) {
       console.error(error, 'setSchema');
     }
@@ -266,8 +272,8 @@ const useForm = props => {
           ? newSchema(newFlatten[path].schema)
           : newSchema;
       newFlatten[path].schema = { ...newFlatten[path].schema, ..._newSchema };
-      setState({ flatten: newFlatten });
-      _flatten.current = newFlatten;
+
+      schemaRef.current = getSchemaFromFlatten(newFlatten);
     } catch (error) {
       console.error(error, 'setSchemaByPath');
     }

--- a/packages/form-render/src/form-render-core/src/utils.js
+++ b/packages/form-render/src/form-render-core/src/utils.js
@@ -163,7 +163,9 @@ export function getSchemaFromFlatten(flatten, path = '#') {
           schema.properties[key] = getSchemaFromFlatten(flatten, child);
         }
         if (isListType(schema)) {
-          schema.items.properties[key] = getSchemaFromFlatten(flatten, child);
+          if (schema.items.properties[key]) {
+            schema.items.properties[key] = getSchemaFromFlatten(flatten, child);
+          }
         }
       });
     }


### PR DESCRIPTION
修复 使用 setSchema 或者 setSchemaByPath 修改 TableList 中的 items 的 schema 无效的问题，具体可查看 [demo](https://codesandbox.io/s/hardcore-shadow-4j2gil?file=/App.jsx)
1. 使用 `setSchema` 和 `setSchemaByPath` 只能修改 对应 path 里的 schema，但是在 list 如 TableList 组件，修改 items 中的schema 没有同步修改 flatten，导致重新渲染的时候没有更新 list 的 items
2. 修改的方式为每次使用 `setSchema` 和 `setSchemaByPath`  时同步修改 schemaRef.current，然后触发修改 flatten，每次 state 更新时会更新  _flatten.current，所以不在 `setSchema` 和 `setSchemaByPath`  中修改 _flatten.current