### PR TITLE
docs: 修复文档中 settings 链接地址错误

### DIFF
--- a/docs/generator/index.md
+++ b/docs/generator/index.md
@@ -54,9 +54,9 @@ export default Demo;
 | transformer        | schema 双向转换          | `object`   | `{ from, to, fromSetting, toSetting }`                                                                                     |
 | extraButtons       | 操作栏按钮               | `array`    | `extraButton[]`                                                                                                            |
 | controlButtons     | 选中项操作按钮           | `array`    | `controlButton[]`                                                                                                          |
-| settings           | 左右侧栏配置             | `array`    | [`defaultSettings`](https://github.com/alibaba/form-render/blob/master/tools/schema-generator/src/Settings/index.js)       |
-| commonSettings     | 通用配置                 | `object`   | [`defaultCommonSettings`](https://github.com/alibaba/form-render/blob/master/tools/schema-generator/src/Settings/index.js) |
-| globalSettings     | 全局配置                 | `object`   | [`defaultGlobalSettings`](https://github.com/alibaba/form-render/blob/master/tools/schema-generator/src/Settings/index.js) |
+| settings           | 左右侧栏配置             | `array`    | [`defaultSettings`](https://github.com/alibaba/form-render/blob/master/tools/schema-generator/src/settings/index.js)       |
+| commonSettings     | 通用配置                 | `object`   | [`defaultCommonSettings`](https://github.com/alibaba/form-render/blob/master/tools/schema-generator/src/settings/index.js) |
+| globalSettings     | 全局配置                 | `object`   | [`defaultGlobalSettings`](https://github.com/alibaba/form-render/blob/master/tools/schema-generator/src/settings/index.js) |
 | widgets            | 自定义组件               | `object`   | `{}`                                                                                                                       |
 | mapping            | 组件和 schema 的映射规则 | `object`   | `{}`                                                                                                                       |
 | validation         | 是否启用配置表单校验     | `boolean`  | `true`                                                                                                                     |

--- a/tools/schema-generator/README.md
+++ b/tools/schema-generator/README.md
@@ -48,9 +48,9 @@ export default Demo;
 | transformer    | schema 双向转换          | `object`  | `{ fromFormRender, toFormRender }`                                                                                              |
 | extraButtons   | 操作栏按钮               | `array`   | `extraButton[]`                                                                                                                 |
 | controlButtons | 选中项操作按钮           | `array`   | `controlButton[]`                                                                                                               |
-| settings       | 左右侧栏配置             | `array`   | [`defaultSettings`](https://github.com/alibaba/form-render/blob/master/tools/schema-generator/src/Settings/index.js#L651)       |
-| commonSettings | 通用配置                 | `object`  | [`defaultCommonSettings`](https://github.com/alibaba/form-render/blob/master/tools/schema-generator/src/Settings/index.js#L2)   |
-| globalSettings | 全局配置                 | `object`  | [`defaultGlobalSettings`](https://github.com/alibaba/form-render/blob/master/tools/schema-generator/src/Settings/index.js#L672) |
+| settings       | 左右侧栏配置             | `array`   | [`defaultSettings`](https://github.com/alibaba/form-render/blob/master/tools/schema-generator/src/settings/index.js#L651)       |
+| commonSettings | 通用配置                 | `object`  | [`defaultCommonSettings`](https://github.com/alibaba/form-render/blob/master/tools/schema-generator/src/settings/index.js#L20)   |
+| globalSettings | 全局配置                 | `object`  | [`defaultGlobalSettings`](https://github.com/alibaba/form-render/blob/master/tools/schema-generator/src/settings/index.js#L831) |
 | widgets        | 自定义组件               | `object`  | `{}`                                                                                                                            |
 | mapping        | 组件和 schema 的映射规则 | `object`  | `{}`                                                                                                                            |
 


### PR DESCRIPTION
文档中有几处地址错误，已修正。
<img width="1246" alt="image" src="https://user-images.githubusercontent.com/9278645/165898686-646227e6-abc7-422f-941d-4f8236c09e04.png">
<img width="971" alt="image" src="https://user-images.githubusercontent.com/9278645/165898814-0d4e66dd-8afb-4f62-bdef-fc0c07972b3d.png">
