### PR TITLE
删掉 ellipsis 的类型

### DIFF
--- a/docs/table-render/index.md
+++ b/docs/table-render/index.md
@@ -217,6 +217,7 @@ columns 为 antd 已有的 props，支持 antd 所有的 [columns](https://ant.d
 
 | 属性      | 描述                                                | 类型                                                  | 默认值 |
 | --------- | --------------------------------------------------- | ----------------------------------------------------- | ------ |
+| ellipsis  | 是否自动缩略                                        | `boolean`                                               | -      |
 | copyable  | 是否支持复制                                        | `boolean`                                               | -      |
 | valueType | 值的类型，详见 [ValueType](#valuetype)                 | `'text' \| 'money' \| 'date' \| 'dateTime'` | text |
 | enum      | 当前列值的枚举，详见[Enum](#enum) | `object`                                              | -      |

--- a/docs/table-render/index.md
+++ b/docs/table-render/index.md
@@ -217,7 +217,6 @@ columns 为 antd 已有的 props，支持 antd 所有的 [columns](https://ant.d
 
 | 属性      | 描述                                                | 类型                                                  | 默认值 |
 | --------- | --------------------------------------------------- | ----------------------------------------------------- | ------ |
-| ellipsis  | 是否自动缩略                                        | `boolean`                                               | -      |
 | copyable  | 是否支持复制                                        | `boolean`                                               | -      |
 | valueType | 值的类型，详见 [ValueType](#valuetype)                 | `'text' \| 'money' \| 'date' \| 'dateTime'` | text |
 | enum      | 当前列值的枚举，详见[Enum](#enum) | `object`                                              | -      |

--- a/packages/table-render/src/interface.ts
+++ b/packages/table-render/src/interface.ts
@@ -24,8 +24,6 @@ export interface TableContext<RecordType> {
 
 export type ProColumnsType<T extends object = any> = Array<
   ColumnsType<T>[number] & {
-    /** 是否自动缩略 */
-    ellipsis?: boolean;
     /** 是否支持复制 */
     copyable?: boolean;
     /** 值的类型 */


### PR DESCRIPTION
ellipsis 在 antd 的 [ColumnsType](https://ant.design/components/table-cn/#Column) 中已经有了，可以去掉。否则 ts 会报错