### PR TITLE
新增 requiredMark 特性；调整 ErrorMessage 和 Extra 的位置，与 ant-design 规范保持一致

### DIFF
--- a/packages/form-render/package.json
+++ b/packages/form-render/package.json
@@ -1,6 +1,6 @@
 {
   "name": "form-render",
-  "version": "1.13.8-beta.3",
+  "version": "1.13.8-beta.5",
   "description": "通过 JSON Schema 生成标准 Form，常用于自定义搭建配置界面生成",
   "keywords": [
     "Form",

--- a/packages/form-render/src/form-render-core/src/core/RenderField/ErrorMessage.js
+++ b/packages/form-render/src/form-render-core/src/core/RenderField/ErrorMessage.js
@@ -11,6 +11,9 @@ const ErrorMessage = ({ message, schema, softHidden, hardHidden }) => {
 
   msg = translateMessage(msg, schema);
 
+  // 无错误信息不渲染 msg 元素占位，表单之间的间隔通过 field-block 元素分隔
+  if(!msg) return null;
+
   if (hardHidden) return <div className={`error-message`}></div>;
 
   return !msg && softHidden ? null : (

--- a/packages/form-render/src/form-render-core/src/core/RenderField/ErrorMessage.less
+++ b/packages/form-render/src/form-render-core/src/core/RenderField/ErrorMessage.less
@@ -6,4 +6,8 @@
     line-height: 1.5715;
     transition: color 0.3s cubic-bezier(0.215, 0.61, 0.355, 1);
   }
+
+  .field-block {
+    min-height: 24px;
+  }
 }

--- a/packages/form-render/src/form-render-core/src/core/RenderField/Title.js
+++ b/packages/form-render/src/form-render-core/src/core/RenderField/Title.js
@@ -35,9 +35,10 @@ const Title = ({
   schema,
   displayType,
   renderTitle,
+  requiredMark: globalRequiredMark,
 }) => {
   const { displayType: globalDisplayType, readOnly, colon } = useStore2();
-  const { title, required, type } = schema;
+  const { title, required, type, requiredMark: schemaRequiredMark } = schema;
   const isObjType = type === 'object';
 
   let _displayType =
@@ -54,6 +55,36 @@ const Title = ({
     });
   }
 
+  const requiredMark = typeof schemaRequiredMark === 'undefined' ? globalRequiredMark : schemaRequiredMark;
+
+  // 左侧的的 * 号提示
+  let TitleRequiredMark = null;
+  // 左侧的 option 提示
+  let TitleTextMark = null;
+
+  if(required) {
+    /**
+     * ant-design requiredMark 实现
+     * https://ant.design/components/form-cn/
+     */
+    if(requiredMark !== false && requiredMark !== 'optional') {
+      TitleRequiredMark = <span className="fr-label-required"> *</span>;
+      TitleTextMark = null;
+    }
+  } else {
+    if(requiredMark === 'optional') {
+      TitleRequiredMark = null;
+      TitleTextMark = <span className="fr-label-required-text">（可选）</span>;
+    }
+  }
+
+  // requiredMark 为 false 不展示必填符号
+  if(requiredMark === false) {
+    TitleRequiredMark = null;
+    TitleTextMark = null;
+  }
+
+
   return (
     <div className={labelClass} style={labelStyle}>
       {title ? (
@@ -67,7 +98,7 @@ const Title = ({
           }`} // checkbox不带冒号
           title={title}
         >
-          {required === true && <span className="fr-label-required"> *</span>}
+          {TitleRequiredMark}
           <span
             className={`${isObjType ? 'b' : ''} ${
               _displayType === 'column' ? 'flex-none' : ''
@@ -75,6 +106,7 @@ const Title = ({
           >
             <span dangerouslySetInnerHTML={{ __html: title }} />
           </span>
+          {TitleTextMark}
           <Description schema={schema} displayType={_displayType} />
         </label>
       ) : null}

--- a/packages/form-render/src/form-render-core/src/core/RenderField/index.js
+++ b/packages/form-render/src/form-render-core/src/core/RenderField/index.js
@@ -43,6 +43,7 @@ const RenderField = props => {
     touchKey,
     _setErrors,
     renderTitle,
+    requiredMark,
   } = useTools();
   const formDataRef = useRef();
   formDataRef.current = formData;
@@ -126,6 +127,7 @@ const RenderField = props => {
     schema: _schema,
     displayType,
     renderTitle,
+    requiredMark,
   };
 
   const messageProps = {
@@ -180,8 +182,9 @@ const RenderField = props => {
         {_showTitle && <div {...placeholderTitleProps} />}
         <div className={contentClass} style={contentStyle}>
           <ExtendedWidget {...widgetProps} />
-          <Extra {...widgetProps} />
           <ErrorMessage {...messageProps} />
+          <Extra {...widgetProps} />
+          <div className='field-block'></div>
         </div>
       </>
     );
@@ -194,6 +197,7 @@ const RenderField = props => {
       <div style={{ display: 'flex' }}>
         {titleElement}
         <ErrorMessage {...messageProps} />
+        <div className='field-block'></div>
       </div>
     );
     return (
@@ -216,8 +220,9 @@ const RenderField = props => {
         style={contentStyle}
       >
         <ExtendedWidget {...widgetProps} />
-        <Extra {...widgetProps} />
         <ErrorMessage {...messageProps} />
+        <Extra {...widgetProps} />
+        <div className='field-block'></div>
       </div>
     </>
   );

--- a/packages/form-render/src/form-render-core/src/index.js
+++ b/packages/form-render/src/form-render-core/src/index.js
@@ -56,6 +56,7 @@ function App({
   globalProps = {},
   methods = {},
   renderTitle,
+  requiredMark,
   ...rest
 }) {
   try {
@@ -221,6 +222,7 @@ function App({
       mapping: { ...defaultMapping, ...mapping },
       onValuesChange,
       renderTitle,
+      requiredMark,
       methods,
       ...form,
       // setEditing,

--- a/packages/form-render/src/form-render-core/src/index.less
+++ b/packages/form-render/src/form-render-core/src/index.less
@@ -114,6 +114,13 @@
     font-family: SimSun, sans-serif;
   }
 
+  .fr-label-required-text {
+    margin: 0 4px 0 0;
+    color: rgba(0, 0, 0, 0.45);
+    font-size: 14px;
+    font-family: SimSun, sans-serif;
+  }
+
   .fr-label-title::after {
     content: ':';
     position: relative;


### PR DESCRIPTION
## 新增 requiredMark 特性

```
{
  "type": "object",
  "properties": {
    "input": {
      "title": "简单输入框",
      "requiredMark": "optional",
      "type": "string",
      "min": 6,
      "rules": [
        {
          "pattern": "^[A-Za-z0-9]+$",
          "message": "只允许填写英文字母和数字"
        }
      ]
    }
  }
}
```

![image](https://user-images.githubusercontent.com/16316329/175460583-b3adeccd-a4af-479f-85e5-1c01e9d7c61d.png)


```
{
  "type": "object",
  "properties": {
    "input": {
      "title": "简单输入框",
      "requiredMark": true,
      "required": true,
      "type": "string",
      "min": 6,
      "rules": [
        {
          "pattern": "^[A-Za-z0-9]+$",
          "message": "只允许填写英文字母和数字"
        }
      ]
    }
  }
}
```

![image](https://user-images.githubusercontent.com/16316329/175460673-a63728b6-75a1-4b0d-9a18-c19034ddb119.png)

## 调整 ErrorMessage 和 Extra 的相对位置


![image](https://user-images.githubusercontent.com/16316329/175460462-fb44fd09-8864-4c4c-90d2-aa17350b833e.png)
