### PR TITLE
fix: 移除generator中的dependencies的antd

### DIFF
--- a/tools/schema-generator/package.json
+++ b/tools/schema-generator/package.json
@@ -22,7 +22,6 @@
     ]
   },
   "dependencies": {
-    "antd": "^4.4.2",
     "clone": "^2.1.2",
     "copy-text-to-clipboard": "^2.2.0",
     "form-render": "^1.0.0",


### PR DESCRIPTION
避免项目存在2个antd依赖，会导致各种问题