### PR TITLE
Feature/empty global settings

### DIFF
--- a/tools/schema-generator/src/components/Settings/index.jsx
+++ b/tools/schema-generator/src/components/Settings/index.jsx
@@ -14,7 +14,7 @@ export default function Settings({ widgets }) {
     showRight: true,
     showItemSettings: false,
   });
-  const { selected } = useStore();
+  const { selected, userProps = {} } = useStore();
   const { tabsKey, showRight, showItemSettings } = state;
 
   const toggleRight = () => setState({ showRight: !showRight });
@@ -47,6 +47,8 @@ export default function Settings({ widgets }) {
     }
   }, [selected]);
 
+  const globalSettingIsEmpty = userProps.globalSettings && !Object.keys(userProps.globalSettings).length;
+
   return showRight ? (
     <div className="right-layout relative pl2">
       <ToggleIcon />
@@ -56,9 +58,11 @@ export default function Settings({ widgets }) {
             <ItemSettings widgets={widgets} />
           </TabPane>
         )}
-        <TabPane tab="表单配置" key="globalSettings">
-          <GlobalSettings widgets={widgets} />
-        </TabPane>
+        {!globalSettingIsEmpty && (
+          <TabPane tab="表单配置" key="globalSettings">
+            <GlobalSettings widgets={widgets} />
+          </TabPane>
+        )}
       </Tabs>
     </div>
   ) : (

--- a/tools/schema-generator/src/components/Settings/index.jsx
+++ b/tools/schema-generator/src/components/Settings/index.jsx
@@ -47,7 +47,7 @@ export default function Settings({ widgets }) {
     }
   }, [selected]);
 
-  const globalSettingIsEmpty = userProps.globalSettings && !Object.keys(userProps.globalSettings).length;
+  const globalSettingHide = userProps.globalSettings === null || (userProps.globalSettings && !Object.keys(userProps.globalSettings).length);
 
   return showRight ? (
     <div className="right-layout relative pl2">
@@ -58,7 +58,7 @@ export default function Settings({ widgets }) {
             <ItemSettings widgets={widgets} />
           </TabPane>
         )}
-        {!globalSettingIsEmpty && (
+        {!globalSettingHide && (
           <TabPane tab="表单配置" key="globalSettings">
             <GlobalSettings widgets={widgets} />
           </TabPane>


### PR DESCRIPTION
generator传入globalSettings为null或{}时允许隐藏generator的表单配置模块