### PR TITLE
fix: 修复table-render search传递schema丢失函数props

### DIFF
--- a/packages/table-render/src/components/Search.tsx
+++ b/packages/table-render/src/components/Search.tsx
@@ -3,6 +3,7 @@ import SearchForm from 'form-render';
 import React, { useEffect, useRef, useState } from 'react';
 import { SearchProps } from '../interface';
 import { useTable } from './hooks';
+import { cloneDeep } from 'lodash-es'
 
 const SearchBtn = ({
   clearSearch,
@@ -92,7 +93,7 @@ const Search: <RecordType extends object = any>(
     if (_schema && _schema.properties) {
       if (formSchema && noDiff) return;
       try {
-        const curSchema = JSON.parse(JSON.stringify(_schema));
+        const curSchema = cloneDeep(_schema);
         curSchema.properties.searchBtn = {
           type: 'string',
           widget: 'searchBtn',


### PR DESCRIPTION
search的表单schema 传递函数时,参数会丢失，例如
```
    created_at: {
      title: '创建时间',
      type: 'string',
       "type": "range",
      format: 'date',
      width: '30%',
      props: {
        onCalendarChange: (val) => {
          console.log('val', val)
        }
      }
    }
```
onCalendarChange会被清除。

问题看起来比较严重，麻烦尽快修复下，感谢