### PR TITLE
fix: Search组件在searchOnMount参数和onMount都存在时，先执行onMount;

### DIFF
--- a/packages/table-render/src/components/Search.tsx
+++ b/packages/table-render/src/components/Search.tsx
@@ -119,18 +119,25 @@ const Search: <RecordType extends object = any>(
   }, [_schema]);
 
   useEffect(() => {
+    init();
+  }, []);
+
+  async function init() {
     syncMethods({
       searchApi: props.api,
       syncAfterSearch: props.afterSearch,
     });
     if (!props.hidden && searchOnMount) {
+      if (typeof searchFormProps.onMount === 'function') {
+        await searchFormProps.onMount();
+      }
       form.submit();
     }
     // 隐藏search组件时，不会触发form.submit
     if (props.hidden) {
       refresh();
     }
-  }, []);
+  }
 
   const btnProps = {
     searchBtnRender,


### PR DESCRIPTION
场景: Search组件里某些选项需要通过网络请求获取，并且需要在页面首次运行时进行搜索行为;

需求: 必须得等Serach组件的onMount执行完之后再执行搜索行为;

临时解决方案: 
`
const Demo: React.FC<{}> = ({}) => {
    const {refresh} = useTable();
    return (
        <Search
        schema={schema}
        api={getTableData as any}
        searchOnMount={false}
        onMount={async () => {
            await 获取数据();
            form.setSchema({});
            refresh?.();
        }}
        searchBtnRender={() => [(
          <Button
            type='primary'
            onClick={form.submit}
            icon={<SearchOutlined/>}
          >查询</Button>
        )]}
      />
   );
}`