### PR TITLE
fix: fr-generator editor styles

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,8 +11,6 @@ yarn
 yarn build
 # 将文档网站跑起来
 yarn start
-# windows环境
-yarn start-win
 ```
 
 #### 3. 进入文档网站了，如何开发呢？

--- a/tools/schema-generator/src/components/Settings/index.jsx
+++ b/tools/schema-generator/src/components/Settings/index.jsx
@@ -27,7 +27,7 @@ export default function Settings({ widgets }) {
       style={{ height: 30, width: 30, padding: '8px 0 0 8px' }}
       onClick={toggleRight}
     >
-      <RightOutlined className="f5" />
+      <RightOutlined style={{color: '#666'}} />
     </div>
   );
 

--- a/tools/schema-generator/src/components/Settings/index.less
+++ b/tools/schema-generator/src/components/Settings/index.less
@@ -7,6 +7,17 @@
   height: 100%;
 }
 
+// 统一左右编辑区滚动条样式
+.fr-generator-container .right-layout ::-webkit-scrollbar {
+  width: 5px;
+  background-color: #0001;
+}
+
+.fr-generator-container .right-layout ::-webkit-scrollbar-thumb {
+  background: #0003;
+  border-radius: 5px;
+}
+
 @media screen and (min-width: 60em) {
   .fr-generator-container .right-layout {
     width: 16rem;

--- a/tools/schema-generator/src/components/Sidebar/Element.less
+++ b/tools/schema-generator/src/components/Sidebar/Element.less
@@ -1,5 +1,5 @@
 .left-item {
-  width: 7.2rem;
+  width: 7.0rem;
   height: 2.2rem;
   display: flex;
   margin: 4px;

--- a/tools/schema-generator/src/components/Sidebar/index.less
+++ b/tools/schema-generator/src/components/Sidebar/index.less
@@ -5,6 +5,17 @@
   height: 100%;
 }
 
+// 修复 Windows 滚动条太宽导致两列布局变成一列
+.left-layout::-webkit-scrollbar {
+  width: 5px;
+  background-color: #0001;
+}
+
+.left-layout::-webkit-scrollbar-thumb {
+  background: #0003;
+  border-radius: 5px;
+}
+
 .left-layout ul {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
There are some problems in the left and right areas:
1. The left Sidebar area width is 7.2 rem, but with Windows scrollbar, it will change from two columns to one;
2. The right Setting area has a ToggleIcon on the top, whose color is the same as background;
- before
![before](https://github.com/zhichaosong/zhichaosong.github.io/blob/master/static/image/fix-fr-generator-before.png?raw=true)
- after
![after](https://github.com/zhichaosong/zhichaosong.github.io/blob/master/static/image/fix-fr-generator-styles.png?raw=true)
------
左右编辑区域有几个问题：
1. 左侧组件区域宽度固定为 7.2 rem，在 Windows 电脑上的滚动条较宽，这会导致组件变成只有一列；
2. 右侧设置区域顶部的折叠按钮颜色跟背景相同，不容易分辨；