### PR TITLE
chore(antd): 继续调整部分弃用API

### DIFF
--- a/packages/form-render/src/form-render-core/src/core/RenderChildren/RenderList/DrawerList.js
+++ b/packages/form-render/src/form-render-core/src/core/RenderChildren/RenderList/DrawerList.js
@@ -215,11 +215,11 @@ const DrawerList = ({
           : null}
       </div>
       <Drawer
-        width="600"
+        width={600}
         title={actionColumnProps.colHeaderText}
         placement="right"
         onClose={closeDrawer}
-        visible={showDrawer}
+        open={showDrawer}
         destroyOnClose // 必须要加，currentIndex不是一个state，Core不会重新渲染就跪了
       >
         <div className="fr-container">

--- a/packages/form-render/src/widgets/antd/percentSlider.js
+++ b/packages/form-render/src/widgets/antd/percentSlider.js
@@ -61,7 +61,7 @@ const PercentSlider = p => {
         {...setting}
         onChange={handleChange}
         max={100}
-        tipFormatter={v => v + '%'}
+        tooltip={{ formatter: v => v + '%' }}
         value={numberValue || 100}
         disabled={p.disabled || p.readonly}
       />

--- a/packages/table-render/src/components/ToolBarAction/DensityIcon.tsx
+++ b/packages/table-render/src/components/ToolBarAction/DensityIcon.tsx
@@ -1,7 +1,8 @@
 import { ColumnHeightOutlined } from '@ant-design/icons';
-import { Dropdown, Menu, Tooltip } from 'antd';
+import { Dropdown, Tooltip } from 'antd';
 import React, { useRef } from 'react';
 import { useTable } from '../hooks';
+import { MenuProps } from 'antd/lib/menu';
 
 export type DensitySize = 'middle' | 'small' | 'default' | undefined;
 
@@ -9,25 +10,26 @@ const DesityIcon = () => {
   const { tableState, setTable }: any = useTable();
   const dropRef = useRef<any>(); // class组件用 React.createRef()
 
+  const menuProps: MenuProps = {
+    items: [
+      { label: '默认', key: 'default' },
+      { label: '中等', key: 'middle' },
+      { label: '紧凑', key: 'small' },
+    ],
+    selectedKeys: [tableState.tableSize],
+    onClick: ({ key }) => {
+      setTable({ tableSize: key as DensitySize });
+    },
+    style: {
+      width: 80,
+    },
+  };
+
   return (
     <div ref={dropRef}>
       <Dropdown
         getPopupContainer={() => dropRef.current}
-        overlay={
-          <Menu
-            selectedKeys={[tableState.tableSize]}
-            onClick={({ key }) => {
-              setTable({ tableSize: key as DensitySize });
-            }}
-            style={{
-              width: 80,
-            }}
-          >
-            <Menu.Item key="default">默认</Menu.Item>
-            <Menu.Item key="middle">中等</Menu.Item>
-            <Menu.Item key="small">紧凑</Menu.Item>
-          </Menu>
-        }
+        menu={menuProps}
         trigger={['click']}
       >
         <Tooltip title="表格密度">

--- a/tools/schema-generator/src/widgets/percentSlider.jsx
+++ b/tools/schema-generator/src/widgets/percentSlider.jsx
@@ -62,7 +62,7 @@ const PercentSlider = p => {
         {...setting}
         onChange={handleChange}
         max={100}
-        tipFormatter={v => v + '%'}
+        tooltip={{ formatter: v => v + '%' }}
         value={numberValue || 100}
         disabled={p.disabled || p.readonly}
       />


### PR DESCRIPTION
继续调整`ant design`废弃的api。
除0.x版本、及动态渲染的`Tabs`外，基本调整完成