### PR TITLE
build(单元测试): 优化配置，fix引入路径问题，支持覆盖率生成

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.17.2",
+    "@babel/plugin-transform-react-jsx": "^7.19.0",
     "@babel/preset-env": "^7.16.11",
     "@babel/preset-react": "^7.16.7",
     "@jest/types": "^27.5.1",
@@ -53,6 +54,7 @@
     "@umijs/preset-react": "1.x",
     "@umijs/test": "^3.0.5",
     "@vitejs/plugin-react": "^3.0.0",
+    "@vitest/coverage-c8": "^0.25.8",
     "@vitest/ui": "^0.25.7",
     "@wojtekmaj/enzyme-adapter-react-17": "^0.6.7",
     "antd": "^4.x",

--- a/packages/form-render/__tests__/demo.tsx
+++ b/packages/form-render/__tests__/demo.tsx
@@ -1,6 +1,7 @@
-import React, { useState } from 'react';
-import FormRender, { useForm } from '../es';
-import { listSchema, normalSchema } from './schema';
+import * as React from 'react';
+import { useState } from 'react';
+import FormRender, { useForm } from '../src/index';
+import { normalSchema } from './schema';
 
 const SimpleForm = () => {
   const form = useForm();

--- a/packages/form-render/__tests__/form-demo.tsx
+++ b/packages/form-render/__tests__/form-demo.tsx
@@ -1,5 +1,6 @@
-import React, { useState } from 'react';
-import FormRender, { useForm } from '../es';
+import * as React from 'react';
+import { useState } from 'react';
+import FormRender, { useForm } from '../src/index';
 
 const schema = {
   type: 'object',

--- a/packages/form-render/__tests__/form-fields.spec.tsx
+++ b/packages/form-render/__tests__/form-fields.spec.tsx
@@ -1,5 +1,5 @@
 import { describe, test, afterAll, expect } from 'vitest';
-import React from 'react';
+import * as React from 'react';
 import '@testing-library/jest-dom';
 import { render, act, cleanup } from '@testing-library/react';
 import Demo from './form-demo';

--- a/packages/form-render/package.json
+++ b/packages/form-render/package.json
@@ -48,8 +48,7 @@
     "prepare": "npm run build",
     "prettier": "prettier --write \"**/*.{js,jsx,tsx,ts,less,md,json}\"",
     "postpublish": "git push --tags",
-    "test": "umi-test",
-    "test:coverage": "umi-test --coverage"
+    "test:ui": "vitest --ui"
   },
   "lint-staged": {
     "*.{js,jsx,less,md,json}": [

--- a/packages/table-render/__tests__/utils.spec.ts
+++ b/packages/table-render/__tests__/utils.spec.ts
@@ -1,4 +1,4 @@
-import { describe, test, afterAll, expect } from 'vitest';
+import { describe, expect, test } from 'vitest';
 import { getDate, getDateTime, getMoneyType, isObj } from '../src/utils';
 
 describe('Test TableRender valueType', () => {

--- a/packages/table-render/package.json
+++ b/packages/table-render/package.json
@@ -29,8 +29,7 @@
     "postpublish": "git push --tags",
     "site": "dumi build",
     "start": "dumi dev",
-    "test": "umi-test",
-    "test:coverage": "umi-test --coverage"
+    "test:ui": "vitest --ui"
   },
   "lint-staged": {
     "*.{js,jsx,less,md,json}": [

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,7 +4,13 @@ import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
 
 export default defineConfig({
-  plugins: [react()],
+  plugins: [
+    react({
+      babel: {
+        plugins: ['@babel/plugin-transform-react-jsx'],
+      },
+    }) as any,
+  ],
   test: {
     globals: true,
     environment: 'jsdom',


### PR DESCRIPTION
针对`vitest`配置进行优化
1. fix引入路径
![image](https://user-images.githubusercontent.com/53564781/208242712-0266ae12-e1b3-4849-8111-09d55d398f11.png)
2. `vitest`单元测试支持`.js`中使用`jsx`语法（`vitest`官方默认不支持，需配置，详见[issure 1564](https://github.com/vitest-dev/vitest/issues/1564)）
3. 添加依赖`@vitest/coverage-c8`，以支持覆盖率收集
4. 修复测试文件中的ts报错