### PR TITLE
feat(async-validator): 增强async-validator的关联性，增强format的检查

### DIFF
--- a/docs/form-render/demos/customMessage.jsx
+++ b/docs/form-render/demos/customMessage.jsx
@@ -12,7 +12,6 @@ const Demo = () => {
       province: {
         type: 'string',
         placeholder: 'province',
-        required: 'true',
         rules: [
           { required: true, message: "province can't be empty" },
           { pattern: '^[a-z]+$', message: 'incorrect province' },
@@ -22,7 +21,6 @@ const Demo = () => {
       city: {
         type: 'string',
         placeholder: 'city',
-        required: 'true',
         rules: [
           { required: true, message: "city can't be empty" },
           { pattern: '^[a-z]+$', message: 'incorrect city' },

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@types/enzyme": "^3.10.11",
     "@types/enzyme-adapter-react-16": "^1.0.6",
     "@types/jest": "^27.0.3",
+    "@types/lodash-es": "^4.17.6",
     "@umijs/plugin-esbuild": "1.x",
     "@umijs/preset-react": "1.x",
     "@umijs/test": "^3.0.5",

--- a/packages/form-render/__tests__/get-descriptor.spec.ts
+++ b/packages/form-render/__tests__/get-descriptor.spec.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from 'vitest';
+import { getDescriptorSimple } from '../src/form-render-core/src/getDescriptorSimple';
+
+// 主要对转换格式进行单元测试
+describe('get-descriptor utils', () => {
+  it('transform test 1', () => {
+    const schema = {
+      title: '代号',
+      type: 'string',
+      required: true,
+      rules: [{ pattern: '^[a-z]+$', message: 'incorrect province' }],
+    };
+
+    const res = getDescriptorSimple(schema, 'count');
+    const expectData = {
+      count: [
+        { required: true, type: 'string' },
+        { pattern: /^[a-z]+$/, message: 'incorrect province' },
+      ],
+    };
+
+    expect(res).toEqual(expectData);
+  });
+
+  it('transform test 2', () => {
+    const schema = {
+      title: '代号',
+      type: 'string',
+      rules: [
+        { required: true, message: '必填' },
+        { pattern: '^[a-z]+$', message: 'incorrect province' },
+      ],
+    };
+
+    const res = getDescriptorSimple(schema, 'count');
+    const expectData = {
+      count: [
+        { required: true, message: '必填' },
+        { pattern: /^[a-z]+$/, message: 'incorrect province' },
+        { type: 'string' },
+      ],
+    };
+
+    expect(res).toEqual(expectData);
+  });
+
+  it('transform test 3', () => {
+    const schema = {
+      title: '代号',
+      type: 'string',
+      rules: [{ pattern: '^[a-z]+$', message: 'incorrect province' }],
+    };
+
+    const res = getDescriptorSimple(schema, 'count');
+
+    const expectData = {
+      count: [
+        { type: 'string' },
+        { pattern: /^[a-z]+$/, message: 'incorrect province' },
+      ],
+    };
+
+    expect(res).toEqual(expectData);
+  });
+
+  it('transform test 4', () => {
+    const schema = {
+      title: '代号',
+      type: 'string',
+      required: true,
+    };
+
+    const res = getDescriptorSimple(schema, 'count');
+
+    const expectData = {
+      count: [{ type: 'string', required: true }],
+    };
+
+    expect(res).toEqual(expectData);
+  });
+
+  it('transform test 5', () => {
+    const schema = {
+      title: '代号',
+      type: 'string',
+    };
+
+    const res = getDescriptorSimple(schema, 'count');
+
+    const expectData = {
+      count: [{ type: 'string' }],
+    };
+
+    expect(res).toEqual(expectData);
+  });
+
+  it('transform test 6', () => {
+    const schema = {
+      title: '时间选择',
+      type: 'string',
+      widget: 'site',
+      format: 'time',
+      required: true,
+    };
+
+    const res = getDescriptorSimple(schema, 'time');
+
+    const expectData =
+      '{"time":[{"required":true},{"type":"string","message":"${title}的格式错误"}]}';
+
+    expect(JSON.stringify(res)).toEqual(expectData);
+  });
+
+  it('transform test 7', () => {
+    const schema = {
+      title: '时间选择',
+      type: 'string',
+      widget: 'site',
+      format: 'time',
+    };
+
+    const res = getDescriptorSimple(schema, 'time');
+    const expectData =
+      '{"time":[{"type":"string","message":"${title}的格式错误"}]}';
+
+    expect(JSON.stringify(res)).toEqual(expectData);
+  });
+
+  it('transform test 9', () => {
+    const schema = {
+      title: '时间选择',
+      type: 'string',
+      widget: 'site',
+      format: 'time',
+      required: true,
+      rules: [{ pattern: '^[a-z]+$', message: 'incorrect province' }],
+    };
+
+    const res = getDescriptorSimple(schema, 'count');
+    const expectData =
+      '{"count":[{"required":true},{"type":"string","message":"${title}的格式错误"},{"pattern":{},"message":"incorrect province"}]}';
+    expect(JSON.stringify(res)).toEqual(expectData);
+  });
+});

--- a/packages/form-render/src/form-render-core/src/core/RenderField/Title.js
+++ b/packages/form-render/src/form-render-core/src/core/RenderField/Title.js
@@ -61,7 +61,16 @@ const Title = ({
   requiredMark: globalRequiredMark,
 }) => {
   const { displayType: globalDisplayType, readOnly, colon } = useStore2();
-  const { title, required, type, requiredMark: schemaRequiredMark } = schema;
+  const {
+    title,
+    required: schemaRequired,
+    type,
+    requiredMark: schemaRequiredMark,
+  } = schema;
+
+  const required =
+    schemaRequired || schema?.rules?.some(r => r?.required === true);
+
   const isObjType = type === 'object';
 
   let _displayType =
@@ -114,7 +123,7 @@ const Title = ({
     <div className={labelClass} style={labelStyle}>
       {title ? (
         <label
-          className={cn( 'fr-label-title',{
+          className={cn('fr-label-title', {
             'no-colon':
               isCheckBoxType(schema, readOnly) ||
               _displayType === 'column' ||

--- a/packages/form-render/src/form-render-core/src/getDescriptorSimple.ts
+++ b/packages/form-render/src/form-render-core/src/getDescriptorSimple.ts
@@ -1,6 +1,6 @@
 import { isEmpty } from 'lodash-es/lodash';
 import { getAlphaFromHex } from '../../widgets/antd/color';
-import * as moment from 'moment';
+import moment from 'moment';
 import { isObject } from './utils';
 import { Schema } from '../../index';
 import { RuleItem, RuleType } from 'async-validator';
@@ -110,7 +110,7 @@ export const getDescriptorSimple = (schema: Schema = {}, path) => {
     // ==================== 处理校验参数 =========================
     // async-validator预设好的类型
     const presetsFormat = ['email', 'url', 'textarea'];
-    if (presetsFormat.includes(schema.format)) {
+    if (presetsFormat.includes(schema.format ?? '')) {
       ruleItem.type =
         schema.format === 'textarea' ? 'string' : (schema.format as RuleType);
     }
@@ -128,7 +128,7 @@ export const getDescriptorSimple = (schema: Schema = {}, path) => {
     }
 
     // 校验时间格式
-    if (['date', 'dateTime', 'time'].includes(schema.format)) {
+    if (['date', 'dateTime', 'time'].includes(schema.format ?? '')) {
       ruleItem.message = '${title}的格式错误';
       ruleItem.validator = (_rule, value) => validatorTime(value);
     }

--- a/packages/form-render/src/form-render-core/src/getDescriptorSimple.ts
+++ b/packages/form-render/src/form-render-core/src/getDescriptorSimple.ts
@@ -1,0 +1,184 @@
+import { isEmpty } from 'lodash-es/lodash';
+import { getAlphaFromHex } from '../../widgets/antd/color';
+import * as moment from 'moment';
+import { isObject } from './utils';
+import { Schema } from '../../index';
+import { RuleItem, RuleType } from 'async-validator';
+import { orderBy } from 'lodash-es';
+
+// 校验时间格式
+function validatorTime(value?: string) {
+  // 不检验空值，交给required决定
+  if (isEmpty(value)) return true;
+
+  //时间段
+  if (Array.isArray(value)) {
+    return value.every(item =>
+      moment(
+        item,
+        [
+          'YYYY-MM-DD',
+          'HH:mm:ss',
+          'YYYY-MM-DD HH:mm:ss',
+          'YYYY-w',
+          'YYYY',
+          'YYYY-MM',
+        ],
+        true
+      ).isValid()
+    );
+  }
+
+  //时间字符串
+  if (typeof value === 'string') {
+    return moment(
+      value,
+      [
+        'YYYY-MM-DD',
+        'HH:mm:ss',
+        'YYYY-MM-DD HH:mm:ss',
+        'YYYY-w',
+        'YYYY',
+        'YYYY-MM',
+      ],
+      true
+    ).isValid();
+  }
+
+  return false;
+}
+
+// 检验color
+function validatorColor(value?: string) {
+  const hexRegex = /^#?([a-f0-9]{6}|[a-f0-9]{3})$/i;
+  // 不检验空值，交给required决定
+  if (isEmpty(value)) return true;
+
+  // 校验hex长度是否合规
+  if (typeof value !== 'string' || ![4, 7, 9].includes(value?.length))
+    return false;
+
+  // 8位hex
+  if (value?.length > 7) {
+    const alpha = getAlphaFromHex(value);
+    const isAlpha = alpha <= 100 && alpha >= 0;
+
+    return hexRegex.test(value.slice(0, 7)) && isAlpha;
+  }
+  // 6位hex
+  return hexRegex.test(value);
+}
+
+// 校验图片格式
+function validatorImage(value?: string) {
+  // 不检验空值，交给required决定
+  if (isEmpty(value)) return true;
+
+  if (typeof value !== 'string') return false;
+
+  // 从0.x迁移过来的正则
+  const imagePattern = '([/|.|w|s|-])*.(?:jpg|gif|png|bmp|apng|webp|jpeg|json)';
+  return new RegExp(imagePattern).test(value);
+}
+
+// 将x-render的schema转为async-validator的格式
+export const getDescriptorSimple = (schema: Schema = {}, path) => {
+  let ruleItem: RuleItem = {};
+  let result: RuleItem[] = [];
+
+  if (isObject(schema)) {
+    if (schema.type) {
+      switch (schema.type) {
+        case 'range':
+          ruleItem.type = 'array';
+          break;
+        case 'html':
+          ruleItem.type = 'string';
+          break;
+        default:
+          ruleItem.type = schema.type as RuleType;
+          break;
+      }
+    }
+
+    ['pattern', 'min', 'max', 'len'].forEach(key => {
+      if (Object.keys(schema).indexOf(key) > -1) {
+        ruleItem[key] = schema[key];
+      }
+    });
+
+    // ==================== 处理校验参数 =========================
+    // async-validator预设好的类型
+    const presetsFormat = ['email', 'url', 'textarea'];
+    if (presetsFormat.includes(schema.format)) {
+      ruleItem.type =
+        schema.format === 'textarea' ? 'string' : (schema.format as RuleType);
+    }
+
+    // 校验hex格式
+    if (schema.format === 'color') {
+      ruleItem.message = '${title}的格式错误';
+      ruleItem.validator = (_rule, value) => validatorColor(value);
+    }
+
+    // 校验image格式
+    if (schema.format === 'image') {
+      ruleItem.message = '${title}的格式错误';
+      ruleItem.validator = (_rule, value) => validatorImage(value);
+    }
+
+    // 校验时间格式
+    if (['date', 'dateTime', 'time'].includes(schema.format)) {
+      ruleItem.message = '${title}的格式错误';
+      ruleItem.validator = (_rule, value) => validatorTime(value);
+    }
+
+    // ==================== 处理用户自定义rules =========================
+    const handleRegx = desc => {
+      if (desc.pattern && typeof desc.pattern === 'string') {
+        desc.pattern = new RegExp(desc.pattern);
+      }
+      return desc;
+    };
+
+    // 处理过程为把required的rule放在数组第一位，先校验required，才会校验pattern或者validator，增加用户体验
+    const isExistValidator = typeof ruleItem.validator === 'function';
+
+    if (schema.rules) {
+      if (Array.isArray(schema.rules)) {
+        const hasRequired = schema.rules.some(rule => rule.required === true);
+
+        if (hasRequired) {
+          result = orderBy(schema.rules, r => (r.required ? 0 : 1)).concat(
+            ruleItem
+          );
+        } else if (!!schema?.required) {
+          result = isExistValidator
+            ? [{ required: true }, ruleItem, ...schema.rules]
+            : [{ required: true, ...ruleItem }, ...schema.rules];
+        } else {
+          result = [ruleItem, ...schema.rules];
+        }
+
+        result = result.map(r => handleRegx(r));
+      } else if (isObject(schema.rules)) {
+        // TODO:实际上渲染UI并未支持这种情况，后期需适配
+        result = schema.rules?.required
+          ? [{ required: true }, ruleItem, schema.rules]
+          : [ruleItem, schema.rules];
+
+        result = result.map(r => handleRegx(r));
+      }
+    } else {
+      if (!!schema?.required) {
+        result = isExistValidator
+          ? [{ required: true }, ruleItem]
+          : [{ required: true, ...ruleItem }];
+      } else {
+        result = [ruleItem];
+      }
+    }
+  }
+
+  return { [path]: result };
+};

--- a/packages/form-render/src/form-render-core/src/utils.js
+++ b/packages/form-render/src/form-render-core/src/utils.js
@@ -10,13 +10,6 @@ export function getParamByName(name, url = window.location.href) {
   return decodeURIComponent(results[2].replace(/\+/g, ' '));
 }
 
-// export function isUrl(string) {
-//   const protocolRE = /^(?:\w+:)?\/\/(\S+)$/;
-//   // const domainRE = /^[^\s\.]+\.\S{2,}$/;
-//   if (typeof string !== 'string') return false;
-//   return protocolRE.test(string);
-// }
-
 export function isCheckBoxType(schema, readOnly) {
   if (readOnly) return false;
   if (schema.widget === 'checkbox') return true;
@@ -266,41 +259,6 @@ export function isDeepEqual(param1, param2) {
   }
   return true;
 }
-
-// export function getFormat(format) {
-//   let dateFormat;
-//   switch (format) {
-//     case 'date':
-//       dateFormat = 'YYYY-MM-DD';
-//       break;
-//     case 'time':
-//       dateFormat = 'HH:mm:ss';
-//       break;
-//     case 'dateTime':
-//       dateFormat = 'YYYY-MM-DD HH:mm:ss';
-//       break;
-//     case 'week':
-//       dateFormat = 'YYYY-w';
-//       break;
-//     case 'year':
-//       dateFormat = 'YYYY';
-//       break;
-//     case 'quarter':
-//       dateFormat = 'YYYY-Q';
-//       break;
-//     case 'month':
-//       dateFormat = 'YYYY-MM';
-//       break;
-//     default:
-//       // dateTime
-//       if (typeof format === 'string') {
-//         dateFormat = format;
-//       } else {
-//         dateFormat = 'YYYY-MM-DD';
-//       }
-//   }
-//   return dateFormat;
-// }
 
 export function hasRepeat(list) {
   return list.find(
@@ -638,14 +596,6 @@ export const getEnum = schema => {
 //   return defaultValue;
 // };
 
-export const isEmail = value => {
-  const regex = '^[a-zA-Z0-9_-]+@[a-zA-Z0-9_-]+(.[a-zA-Z0-9_-]+)+$';
-  if (value && new RegExp(regex).test(value)) {
-    return true;
-  }
-  return false;
-};
-
 export function defaultGetValueFromEvent(valuePropName, ...args) {
   const event = args[0];
   if (event && event.target && valuePropName in event.target) {
@@ -706,63 +656,6 @@ export const removeEmptyItemFromList = formData => {
     result = formData;
   }
   return result;
-};
-
-export const getDescriptorSimple = (schema = {}, path) => {
-  let result = {};
-  if (isObject(schema)) {
-    if (schema.type) {
-      switch (schema.type) {
-        case 'range':
-          result.type = 'array';
-          break;
-        case 'html':
-          result.type = 'string';
-          break;
-        default:
-          result.type = schema.type;
-          break;
-      }
-    }
-    ['pattern', 'min', 'max', 'len', 'required'].forEach(key => {
-      if (Object.keys(schema).indexOf(key) > -1) {
-        result[key] = schema[key];
-      }
-    });
-
-    switch (schema.format) {
-      case 'email':
-      case 'url':
-        result.type = schema.format;
-        break;
-      default:
-        break;
-    }
-
-    const handleRegx = desc => {
-      if (desc.pattern && typeof desc.pattern === 'string') {
-        desc.pattern = new RegExp(desc.pattern);
-      }
-      return desc;
-    };
-    // result be array
-    if (schema.rules) {
-      if (Array.isArray(schema.rules)) {
-        const requiredRule = schema.rules.find(rule => rule.required === true);
-        if (requiredRule) {
-          result = { ...result, ...requiredRule };
-        }
-        result = [result, ...schema.rules];
-        result = result.map(r => handleRegx(r));
-      } else if (isObject(schema.rules)) {
-        result = [result, schema.rules];
-        result = result.map(r => handleRegx(r));
-      }
-    } else {
-      result = [result];
-    }
-  }
-  return { [path]: result };
 };
 
 // _path 只供内部递归使用

--- a/packages/form-render/src/form-render-core/src/validator.js
+++ b/packages/form-render/src/form-render-core/src/validator.js
@@ -6,7 +6,6 @@ import {
   dataToKeys,
   destructDataPath,
   getDataPath,
-  getDescriptorSimple,
   isExpression,
   isObject,
   parseSingleExpression,
@@ -15,6 +14,7 @@ import {
 import { defaultValidateMessages } from './validateMessage';
 import { defaultValidateMessagesCN } from './validateMessageCN';
 import { getRealDataFlatten } from './void';
+import { getDescriptorSimple } from './getDescriptorSimple';
 
 export const parseSchemaExpression = (schema, formData, path) => {
   if (!isObject(schema)) return schema;

--- a/packages/form-render/src/widgets/antd/color.js
+++ b/packages/form-render/src/widgets/antd/color.js
@@ -108,7 +108,7 @@ const alphaHexMap = {
 };
 
 // Exp: "#ffffffA6" => algha: 65
-const getAlphaFromHex = (hex = '#ffffff') => {
+export const getAlphaFromHex = (hex = '#ffffff') => {
   const alphaHex = hex.slice(7);
   let alpha = 100;
   for (const key in alphaHexMap) {

--- a/packages/form-render/tsconfig.json
+++ b/packages/form-render/tsconfig.json
@@ -1,0 +1,40 @@
+{
+  "compilerOptions": {
+    "target": "ES2015",
+    "module": "ES2015",
+    "moduleResolution": "node",
+    "importHelpers": true,
+    "jsx": "react",
+    "esModuleInterop": true,
+    "sourceMap": true,
+    "baseUrl": "./",
+    "declaration": true,
+    "paths": {
+      "@/*": [
+        "src/*"
+      ],
+      "@@/*": [
+        "src/.umi/*"
+      ]
+    },
+    "skipLibCheck": true,
+    "allowSyntheticDefaultImports": true,
+    "noImplicitAny": false
+  },
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.tsx",
+  ],
+  "exclude": [
+    "node_modules",
+    "lib",
+    "es",
+    "dist",
+    "typings",
+    "**/__test__",
+    "test",
+    "tests",
+    "docs",
+    "**/*.js"
+  ]
+}


### PR DESCRIPTION
1. 增强`x-render`与`async-validator`的关联性
2. 加强自带`format`的校验流程（对特定的`format`使用`async-validator`的`validator`校验一次）
    **修改前**
    ![image](https://user-images.githubusercontent.com/53564781/211718766-8878169e-00ce-4195-a5b3-699d4d81c883.png)
  **修改后**
  ![image](https://user-images.githubusercontent.com/53564781/211718864-3a74068c-350d-4035-9a82-6c2eae45cdb5.png)

