### PR TITLE
feat(form-render): rules支持对象形式

### DIFF
--- a/packages/form-render/__tests__/get-descriptor.spec.ts
+++ b/packages/form-render/__tests__/get-descriptor.spec.ts
@@ -141,4 +141,46 @@ describe('get-descriptor utils', () => {
       '{"count":[{"required":true},{"type":"string","message":"${title}的格式错误"},{"pattern":{},"message":"incorrect province"}]}';
     expect(JSON.stringify(res)).toEqual(expectData);
   });
+
+  it('transform test 10', () => {
+    const schema = {
+      title: '代号',
+      type: 'string',
+      required: true,
+      rules: { pattern: '^[a-z]+$', message: 'incorrect province' },
+    };
+
+    const res = getDescriptorSimple(schema, 'count');
+    const expectData = {
+      count: [
+        { required: true, type: 'string' },
+        { pattern: /^[a-z]+$/, message: 'incorrect province' },
+      ],
+    };
+
+    expect(res).toEqual(expectData);
+  });
+
+  it('transform test 11', () => {
+    const schema = {
+      title: '代号',
+      type: 'string',
+
+      rules: {
+        required: true,
+        pattern: '^[a-z]+$',
+        message: 'incorrect province',
+      },
+    };
+
+    const res = getDescriptorSimple(schema, 'count');
+    const expectData = {
+      count: [
+        { required: true, pattern: /^[a-z]+$/, message: 'incorrect province' },
+        { type: 'string' },
+      ],
+    };
+
+    expect(res).toEqual(expectData);
+  });
 });

--- a/packages/form-render/package.json
+++ b/packages/form-render/package.json
@@ -60,7 +60,7 @@
   },
   "dependencies": {
     "@ant-design/icons": "^4.0.2",
-    "async-validator": "^3.5.1",
+    "async-validator": "^4.2.5",
     "classnames": "^2.3.1",
     "color": "^3.1.2",
     "lodash-es": "^4.17.21",

--- a/packages/form-render/src/form-render-core/src/core/RenderField/Title.js
+++ b/packages/form-render/src/form-render-core/src/core/RenderField/Title.js
@@ -68,8 +68,12 @@ const Title = ({
     requiredMark: schemaRequiredMark,
   } = schema;
 
+  // FormItem required
   const required =
-    schemaRequired || schema?.rules?.some(r => r?.required === true);
+    schemaRequired ||
+    (Array.isArray(schema?.rules)
+      ? schema?.rules?.some(r => r?.required === true)
+      : schema?.rules?.required);
 
   const isObjType = type === 'object';
 

--- a/packages/form-render/src/form-render-core/src/getDescriptorSimple.ts
+++ b/packages/form-render/src/form-render-core/src/getDescriptorSimple.ts
@@ -145,30 +145,25 @@ export const getDescriptorSimple = (schema: Schema = {}, path) => {
     const isExistValidator = typeof ruleItem.validator === 'function';
 
     if (schema.rules) {
-      if (Array.isArray(schema.rules)) {
-        const hasRequired = schema.rules.some(rule => rule.required === true);
+      const mergeRules = Array.isArray(schema.rules)
+        ? schema.rules
+        : [schema.rules];
 
-        if (hasRequired) {
-          result = orderBy(schema.rules, r => (r.required ? 0 : 1)).concat(
-            ruleItem
-          );
-        } else if (!!schema?.required) {
-          result = isExistValidator
-            ? [{ required: true }, ruleItem, ...schema.rules]
-            : [{ required: true, ...ruleItem }, ...schema.rules];
-        } else {
-          result = [ruleItem, ...schema.rules];
-        }
+      const hasRequired = mergeRules.some(rule => rule.required === true);
 
-        result = result.map(r => handleRegx(r));
-      } else if (isObject(schema.rules)) {
-        // TODO:实际上渲染UI并未支持这种情况，后期需适配
-        result = schema.rules?.required
-          ? [{ required: true }, ruleItem, schema.rules]
-          : [ruleItem, schema.rules];
-
-        result = result.map(r => handleRegx(r));
+      if (hasRequired) {
+        result = orderBy(mergeRules, r => (r.required ? 0 : 1)).concat(
+          ruleItem
+        );
+      } else if (!!schema?.required) {
+        result = isExistValidator
+          ? [{ required: true }, ruleItem, ...mergeRules]
+          : [{ required: true, ...ruleItem }, ...mergeRules];
+      } else {
+        result = [ruleItem, ...mergeRules];
       }
+
+      result = result.map(r => handleRegx(r));
     } else {
       if (!!schema?.required) {
         result = isExistValidator

--- a/packages/form-render/src/form-render-core/src/utils.js
+++ b/packages/form-render/src/form-render-core/src/utils.js
@@ -703,19 +703,25 @@ export const translateMessage = (msg, schema) => {
     msg = msg.replace('${max}', schema.max);
   }
   if (schema.rules) {
-    const minRule = schema.rules.find(r => r.min !== undefined);
+    const mergeRules = Array.isArray(schema.rules)
+      ? schema.rules
+      : [schema.rules];
+
+    const minRule = mergeRules.find(r => r.min !== undefined);
     if (minRule) {
       msg = msg.replace('${min}', minRule.min);
     }
-    const maxRule = schema.rules.find(r => r.max !== undefined);
+
+    const maxRule = mergeRules.find(r => r.max !== undefined);
     if (maxRule) {
       msg = msg.replace('${max}', maxRule.max);
     }
-    const lenRule = schema.rules.find(r => r.len !== undefined);
+
+    const lenRule = mergeRules.find(r => r.len !== undefined);
     if (lenRule) {
       msg = msg.replace('${len}', lenRule.len);
     }
-    const patternRule = schema.rules.find(r => r.pattern !== undefined);
+    const patternRule = mergeRules.find(r => r.pattern !== undefined);
     if (patternRule) {
       msg = msg.replace('${pattern}', patternRule.pattern);
     }

--- a/packages/form-render/src/form-render-core/src/validator.js
+++ b/packages/form-render/src/form-render-core/src/validator.js
@@ -220,7 +220,7 @@ const validateSingle = (
   const cn = defaultValidateMessagesCN;
   const en = defaultValidateMessages;
   const descriptor = getDescriptorSimple(schema, path);
-  // console.log('descriptor, schema, path', descriptor, schema, path, data);
+
   // TODO: 有些情况会出现没有rules，需要看一下，先兜底
   let validator;
   try {
@@ -234,10 +234,10 @@ const validateSingle = (
   validator.messages(messageFeed);
   return validator
     .validate({ [path]: data })
-    .then(res => {
+    .then(() => {
       return [{ field: path, message: null }];
     })
-    .catch(({ errors, fields }) => {
+    .catch(({ errors }) => {
       return errors;
     })
     .finally(() => {


### PR DESCRIPTION
1. `form-render`配置支持对象形式的`rules`，如下

```js
const schema = {
    title: '代号',
    type: 'string',
    required: true,
    rules: { pattern: '^[a-z]+$', message: 'incorrect province' },
  };
```

2.  更新`async-validator`版本