### PR TITLE
feat: radio、checkboxes 支持选项方向

### DIFF
--- a/packages/form-render/src/widgets-antd/field/checkboxes/index.tsx
+++ b/packages/form-render/src/widgets-antd/field/checkboxes/index.tsx
@@ -1,8 +1,33 @@
 import React from 'react';
-import { Checkbox } from 'antd';
+import { Checkbox, Space } from 'antd';
 
-export default (props: any) => {
-  
+interface Option {
+  label: string;
+  value: string;
+  disabled?: boolean
+}
 
-  return <Checkbox.Group {...props} />;
+interface Props {
+  direction: 'vertical' | 'horizontal';
+  options: Option[];
+  [key: string]: any
+}
+
+export default (props: Props) => {
+  const { direction = 'horizontal', options = [], ...rest } = props
+
+  if (direction === 'vertical') {
+    return <Checkbox.Group {...rest} >
+      <Space direction='vertical'>
+        {
+          options.map((item: Option) => {
+            const { value, label, ...rest } = item
+            return <Checkbox key={value} value={value} {...rest}>{label}</Checkbox>
+          })
+        }
+      </Space>
+    </Checkbox.Group>
+  }
+
+  return <Checkbox.Group {...rest} options={options} />;
 };

--- a/packages/form-render/src/widgets-antd/field/radio/index.tsx
+++ b/packages/form-render/src/widgets-antd/field/radio/index.tsx
@@ -1,3 +1,33 @@
-import { Radio } from 'antd';
+import React from 'react';
+import { Radio, Space } from 'antd';
 
-export default Radio.Group;
+interface Option {
+  label: string;
+  value: string;
+  disabled?: boolean;
+}
+
+interface Props {
+  direction: 'vertical' | 'horizontal',
+  options: string[] | number[] | Option[]
+  [key: string]: any
+}
+
+export default (props: Props) => {
+  const { direction = 'horizontal', options = [], ...rest } = props
+
+  if (direction === 'vertical') {
+    return <Radio.Group {...rest} >
+      <Space direction='vertical'>
+        {
+          options.map((item: Option) => {
+            const { value, label, ...rest } = item
+            return <Radio key={value} value={value} {...rest}>{label}</Radio>
+          })
+        }
+      </Space>
+    </Radio.Group>
+  }
+
+  return <Radio.Group {...rest} options={options} />;
+};

--- a/packages/form-render/src/widgets-antd/field/upload/index.tsx
+++ b/packages/form-render/src/widgets-antd/field/upload/index.tsx
@@ -3,6 +3,16 @@ import { Button, message, Upload, ConfigProvider } from 'antd';
 import { get } from 'lodash-es';
 import React, { useContext } from 'react';
 import { translation } from '../../utils'
+import { ButtonProps } from 'antd/es/button';
+
+interface Props {
+  action: any;
+  value: string;
+  onChange: any;
+  uploadProps: any;
+  buttonProps: ButtonProps;
+  schema: any;
+}
 
 export default function FrUpload({
   action,
@@ -11,7 +21,7 @@ export default function FrUpload({
   uploadProps,
   buttonProps,
   schema,
-}) {
+}: Props) {
   const configCtx = useContext(ConfigProvider.ConfigContext);
   const t = translation(configCtx);
 
@@ -19,7 +29,7 @@ export default function FrUpload({
     name: 'file',
     type: 'file',
     action, // 旧的兼容
-    onChange(info) {
+    onChange(info: any) {
       if (info.file.status === 'done') {
         message.success(`${info.file.name} ${t('upload_success')}`);
         const path = get(schema, 'props.path', '');

--- a/packages/form-render/src/widgets-antd/index.ts
+++ b/packages/form-render/src/widgets-antd/index.ts
@@ -5,6 +5,7 @@ export { default as TextArea } from './field/textArea';
 export { default as Select } from './field/select';
 export { default as MultiSelect } from './field/select';
 export { default as Switch } from './field/switch';
+export { default as Radio } from './field/radio';
 export { default as Rate } from './field/rate';
 export { default as TreeSelect } from './field/treeSelect';
 export { default as CheckBox } from './field/checkbox';


### PR DESCRIPTION
schema中添加：
props: {
  direction: 'vertical'
}
默认为 horizontal

