### PR TITLE
feat: cardList onItemRemove回调新增当前删除的表单值

### DIFF
--- a/packages/form-render/src/render-core/FieldList/main.tsx
+++ b/packages/form-render/src/render-core/FieldList/main.tsx
@@ -24,7 +24,7 @@ export default (props: any) => {
   const { widgets, globalConfig } = configContext;
   const configCtx = useContext(ConfigProvider.ConfigContext);
   const t = translation(configCtx);
- 
+
   const defaultAddBtnProps = {
     type: 'dashed',
     block: true,
@@ -44,7 +44,7 @@ export default (props: any) => {
   let widgetName = schema.widget || 'cardList';
   const Widget = getWidget(widgetName, widgets);
 
-  const { props: listProps,  removeBtn, ...otherSchema } = schema;
+  const { props: listProps, removeBtn, ...otherSchema } = schema;
 
   let defaultValue = schema.default ?? schema.defaultValue;
   if (defaultValue === undefined && !['drawerList', 'list1'].includes(widgetName)) {
@@ -79,14 +79,14 @@ export default (props: any) => {
     add(data);
   };
 
-  const handleRemove = (remove: any) => (index: number) => {
+  const handleRemove = (remove: any) => (index: number, data?: any) => {
     let removeFunc = onRemove;
     if (typeof onRemove === 'string') {
       removeFunc = methods[onRemove];
     }
 
     if (isFunction(removeFunc)) {
-      removeFunc(() => remove(index), { schema, index });
+      removeFunc(() => remove(index), { schema, index, data });
       return;
     }
 
@@ -204,11 +204,11 @@ export default (props: any) => {
               removeItem={handleRemove(operation.remove)}
               moveItem={handleMove(operation.move)}
               copyItem={handleCopy(operation.add, fields)}
-             
+
               temporary={{
                 displayType
               }}
-              
+
 
               addBtnProps={{
                 ...defaultAddBtnProps,

--- a/packages/form-render/src/render-core/FieldList/main.tsx
+++ b/packages/form-render/src/render-core/FieldList/main.tsx
@@ -123,7 +123,7 @@ export default (props: any) => {
     add(value);
   };
 
-  const handleDetele = () => {
+  const handleDelete = () => {
     if (isFunction(removeBtn?.onClick)) {
       removeBtn.onClick(() => {
         form.setSchemaByPath(path, { hidden: true });
@@ -252,7 +252,7 @@ export default (props: any) => {
           type='link'
           danger
           {...removeBtn}
-          onClick={handleDetele}
+          onClick={handleDelete}
         >
           {removeBtn?.text || t('delete')}
         </Button>

--- a/packages/form-render/src/render-core/FieldList/main.tsx
+++ b/packages/form-render/src/render-core/FieldList/main.tsx
@@ -107,7 +107,7 @@ export default (props: any) => {
     move(form, to);
   };
 
-  const handleCopy = (add: any, fields: any) => (value: any) => {
+  const handleCopy = (add: any, fields: any) => (data: any) => {
     if (schema.max && fields.length === schema.max) {
       return message.warning(t('copy_max_tip'));
     }
@@ -117,10 +117,10 @@ export default (props: any) => {
     }
 
     if (isFunction(copyFunc)) {
-      copyFunc((funData?: any) => add(funData || value), { schema, value });
+      copyFunc((funData?: any) => add(funData || data), { schema, data });
       return;
     }
-    add(value);
+    add(data);
   };
 
   const handleDelete = () => {

--- a/packages/form-render/src/widgets/listCard/index.tsx
+++ b/packages/form-render/src/widgets/listCard/index.tsx
@@ -24,7 +24,7 @@ const getOperateStyle = (schema: any) => {
       style.top = '3px';
       style.padding = 0;
     }
-    
+
     if (!schema?.items?.title) {
       style.right = '0';
     }
@@ -47,7 +47,7 @@ const CardList = (props: any) => {
     deleteBtnProps,
     moveUpBtnProps,
     moveDownBtnProps,
-   
+
     hideDelete,
     hideCopy,
     hideMove,
@@ -64,6 +64,11 @@ const CardList = (props: any) => {
     copyItem(value);
   };
 
+  const handleRemove = (name: number) => {
+    const value = form.getFieldValue(rootPath.concat(name));
+    removeItem(name, value);
+  }
+
   return (
     <>
       <div className={classnames('fr-list-card', { 'fr-list-card-background': hasBackground })}>
@@ -78,42 +83,42 @@ const CardList = (props: any) => {
               <div style={{ width: 0, flex: 1 }}>
                 {renderCore({ schema: newSchema, parentPath: [name], rootPath: [...rootPath, name] })}
               </div>
-              <Space 
+              <Space
                 className={classnames('fr-list-item-operate', { 'fr-list-item-operate-fixed': getOperateFixed(schema) })}
                 style={getOperateStyle(schema)}
                 split={operateBtnType !== 'icon' && <Divider type='vertical' />}
               >
                 {!hideMove && (
                   <>
-                    <FButton 
+                    <FButton
                       disabled={name === 0}
                       onClick={() => moveItem(name, name - 1)}
-                      icon={<ArrowUpOutlined/>}
+                      icon={<ArrowUpOutlined />}
                       {...moveUpBtnProps}
                     />
-                    <FButton 
+                    <FButton
                       disabled={name === length - 1}
                       onClick={() => moveItem(name, name + 1)}
-                      icon={<ArrowDownOutlined/>}
+                      icon={<ArrowDownOutlined />}
                       {...moveDownBtnProps}
                     />
                   </>
                 )}
                 {!hideDelete && (
                   <Popconfirm
-                    onConfirm={() => removeItem(name)}
+                    onConfirm={() => handleRemove(name)}
                     {...delConfirmProps}
                   >
                     <FButton
-                      icon={<CloseOutlined/>}
+                      icon={<CloseOutlined />}
                       {...deleteBtnProps}
                     />
                   </Popconfirm>
                 )}
                 {!hideCopy && (
-                  <FButton 
+                  <FButton
                     onClick={() => handleCopy(name)}
-                    icon={<CopyOutlined/>}
+                    icon={<CopyOutlined />}
                     {...copyBtnProps}
                   />
                 )}


### PR DESCRIPTION
- feat: cardList onItemRemove回调新增当前删除的表单值
- breakchange: cardList onItemCopy统一ListItem表单值字段为data(目前 onItemCopy value只有我这边消费)
- 调整拼错的变量名