### PR TITLE
fix: add missing form instance type: getFieldValueByPath

### DIFF
--- a/packages/form-render/src/type.ts
+++ b/packages/form-render/src/type.ts
@@ -205,6 +205,10 @@ export interface FormInstance {
    * 检查某个表单项是否在校验中
    */
   isFieldValidating: AntdFormInstance['isFieldValidating'];
+    /**
+   * 根据路径获取表单值
+   */
+  getValueByPath: AntdFormInstance['getFieldValue'];
   /**
    * 根据路径修改表单值
    */


### PR DESCRIPTION
On your official website, form instance has a function called getValueByPath, but missing in type definition files
<img width="609" alt="image" src="https://github.com/alibaba/x-render/assets/26027055/c68a81cc-3538-41e0-8b29-b2a5e7559f53">
