### PR TITLE
fix: 初始化columnsSettingValue值

### DIFF
--- a/packages/table-render/src/core/ToolbarView/InteriorTool/ColumnSetting/index.tsx
+++ b/packages/table-render/src/core/ToolbarView/InteriorTool/ColumnSetting/index.tsx
@@ -44,9 +44,14 @@ const ColumnSetting: React.FC<Pick<ToolbarActionConfig, 'columnsSettingValue' | 
   }, [open, columns])
 
   const init = () => {
+    const keyMap = columnsSettingValue?.reduce((previousValue, currentValue) => {
+      previousValue[currentValue.key] = currentValue.hidden
+      return previousValue
+    }, {}) || {};
+    
     const initSetting = columns.map((i, index) => ({
       key: getColumnKey(i, index),
-      hidden: false,
+      hidden: keyMap[getColumnKey(i, index)] || false,
     }))
     handleChange(initSetting);
   }

--- a/packages/table-render/src/core/ToolbarView/InteriorTool/ColumnSetting/index.tsx
+++ b/packages/table-render/src/core/ToolbarView/InteriorTool/ColumnSetting/index.tsx
@@ -84,7 +84,11 @@ const ColumnSetting: React.FC<Pick<ToolbarActionConfig, 'columnsSettingValue' | 
   }
 
   const onReset = () => {
-    init();
+    const settingValue = columns.map((i, index) => ({
+      key: getColumnKey(i, index),
+      hidden: false,
+    }))
+    handleChange(settingValue);
   }
 
   /** 固定某一列 */


### PR DESCRIPTION
为解决table-render内置工具栏表格筛选传入指定的columnsSettingValue，首次点击会丢失传入的筛选结果 #1325

issues地址：
https://github.com/alibaba/x-render/issues/1325