### PR TITLE
fix: SearchForm设置layoutAuto，在初次渲染时未触发布局计算

### DIFF
--- a/packages/form-render/src/derivative/SearchForm/index.tsx
+++ b/packages/form-render/src/derivative/SearchForm/index.tsx
@@ -37,7 +37,7 @@ const getSearchHeight = (limitHeight: boolean, isColumn: boolean) => {
   if (!limitHeight) {
     return 'auto';
   }
- 
+
   if (isColumn) {
     return 110;
   }
@@ -67,7 +67,7 @@ const SearchForm: <RecordType extends object = any>(
     style = {},
     className,
     mode,
-    layoutAuto=false,
+    layoutAuto = false,
     form,
     hidden,
     loading,
@@ -135,7 +135,7 @@ const SearchForm: <RecordType extends object = any>(
     }
     setTimeout(() => {
       const { clientHeight } = searchRef?.current;
-     
+
       if (!collapsed && clientHeight > (isColumn ? 110 : 136)) {
         setCollapsed(true);
       }
@@ -154,16 +154,12 @@ const SearchForm: <RecordType extends object = any>(
     }
 
     const resizeObserver = new ResizeObserver(debounce(() => {
-      const { clientWidth, clientHeight } = searchRef?.current || {};
-      if(clientWidth === 0 || clientHeight === 0 || !preWidthRef.current || preWidthRef.current === clientWidth){
-        preWidthRef.current = clientWidth;
-        return;
-      }
+      const { clientWidth } = searchRef?.current || {};
 
       preWidthRef.current = clientWidth;
 
       for (let i = _column; i > 0; i--) {
-        const item = clientWidth/i;
+        const item = clientWidth / i;
         if (item >= (layoutAuto?.fieldMinWidth || 340)) {
           setColumn(i);
           break;
@@ -172,7 +168,9 @@ const SearchForm: <RecordType extends object = any>(
           setColumn(1);
         }
       }
-    }, 300));
+    }, 300, {
+      leading: true,
+    }));
 
     resizeObserver.observe(searchRef.current);
     () => {
@@ -213,7 +211,7 @@ const SearchForm: <RecordType extends object = any>(
 
   return (
     <div
-      className={classnames('fr-search', { [className || '']: !!className,  'fr-column-search': isColumn })}
+      className={classnames('fr-search', { [className || '']: !!className, 'fr-column-search': isColumn })}
       style={{
         ...style,
         height: getSearchHeight(limitHeight, isColumn)
@@ -221,35 +219,37 @@ const SearchForm: <RecordType extends object = any>(
       ref={searchRef}
       onKeyDown={!closeReturnSearch && handleKeyDown}
     >
-      <FormRender
-        displayType='row'
-        {...otherProps}
-        schema={{
-          ...schema,
-          column: column
-        }}
-        onFinish={handleFinish}
-        onFinishFailed={handleFinishFailed}
-        form={form}
-        operateExtra={operateShow && (
-          <Col 
-            className={classnames('search-action-col', { 
-              'search-action-fixed': limitHeight,
-              'search-action-column': isColumn,
-              'search-action-column-fixed': limitHeight && isColumn,
-            })} 
-            style={{ minWidth: (1/column)*100 + '%' }}
-          >
-            <ActionView 
-              {...actionProps} 
-              setLimitHeight={setLimitHeight} 
-              retainBtn={retainBtn} 
-              mode={mode} 
-              setExpand={setExpand} 
-            />
-          </Col>
-        )}
-      />
+      {preWidthRef.current && (
+        <FormRender
+          displayType='row'
+          {...otherProps}
+          schema={{
+            ...schema,
+            column: column
+          }}
+          onFinish={handleFinish}
+          onFinishFailed={handleFinishFailed}
+          form={form}
+          operateExtra={operateShow && (
+            <Col
+              className={classnames('search-action-col', {
+                'search-action-fixed': limitHeight,
+                'search-action-column': isColumn,
+                'search-action-column-fixed': limitHeight && isColumn,
+              })}
+              style={{ minWidth: (1 / column) * 100 + '%' }}
+            >
+              <ActionView
+                {...actionProps}
+                setLimitHeight={setLimitHeight}
+                retainBtn={retainBtn}
+                mode={mode}
+                setExpand={setExpand}
+              />
+            </Col>
+          )}
+        />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
bug说明：
组件的layoutAuto属性应该在初次渲染就计算一次，不然会出现小屏上设置自适应后，手动调整才生效。

代码说明：

1. 这段代码阻碍了初次计算，故删除
```
if(clientWidth === 0 || clientHeight === 0 || !preWidthRef.current || preWidthRef.current === clientWidth){
  preWidthRef.current = clientWidth;
  return;
}
```
2. debounce设置leading属性触发300ms延时前的首次计算
3. `preWidthRef.current && <FormRender ...`，防止因获取容器宽度后修改column造成的首次渲染闪烁
