### PR TITLE
fix: 修复form-render html组件xss攻击问题

### DIFF
--- a/packages/form-render/package.json
+++ b/packages/form-render/package.json
@@ -64,7 +64,8 @@
     "rc-color-picker": "^1.2.6",
     "virtualizedtableforantd4": "^1.1.2",
     "zustand": "^4.1.5",
-    "ahooks": "3.7.5"
+    "ahooks": "3.7.5",
+    "sanitize-html": "^2.11.0"
   },
   "devDependencies": {
     "deep-equal": "^2.0.3",

--- a/packages/form-render/src/widgets/fields/html/index.jsx
+++ b/packages/form-render/src/widgets/fields/html/index.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Image } from 'antd';
+import sanitizeHtml from 'sanitize-html';
 
 export default function html({ value, options, schema = {} }) {
   let __html = '-';
@@ -46,6 +47,8 @@ export default function html({ value, options, schema = {} }) {
       />
     );
   }
+
+  __html = sanitizeHtml(__html)
 
   return <div dangerouslySetInnerHTML={{ __html }} />;
 }


### PR DESCRIPTION
问题：form-render内的html组件在dangerouslySetInnerHTML之前没有做清理，导致可以触发xss攻击。
影响：该组件为默认的readOnlyWidget，当readyOnly为true且没有制定readOnlyWidget时就会使用该组件，安全风险较大。
解决方案：使用sanitize-html库，在设到innerHTML前对内容做清理，详见代码。
<img width="766" alt="Screenshot formrender tsx 2023-10-17 11 AM-18-55" src="https://github.com/alibaba/x-render/assets/47842054/61a08125-bd62-4d3b-8a6c-343bc07e1633">
<img width="1405" alt="Screenshot 2023-10-17 11 AM-16-19" src="https://github.com/alibaba/x-render/assets/47842054/d764c3a4-10f7-4bb3-8593-342484ef45f8">
