### PR TITLE
fix(settings): 动态修改settings,组件配置不渲染的问题修复

### DIFF
--- a/tools/schema-generator/src/components/Settings/ItemSettings.jsx
+++ b/tools/schema-generator/src/components/Settings/ItemSettings.jsx
@@ -117,7 +117,7 @@ export default function ItemSettings({ widgets }) {
       isReady.current = true;
       console.error(error);
     }
-  }, [selected]);
+  }, [selected,settings]);
 
   useEffect(() => {
     validation && onItemErrorChange(form?.errorFields);


### PR DESCRIPTION
<img width="986" alt="image" src="https://github.com/alibaba/x-render/assets/26488273/b277e825-2043-4db5-bcaa-e479299a2d1d">
写了自定义组件，里面的属性的选项是动态的。如上图。
目前我选了上面的属性下面的不会自动渲染，需要取消选择当前组件再重新选择当前组件才能渲染，看了源码改了这里就行了。