### PR TITLE
fix(form-render): switch&&checkbox readonly html value

### DIFF
--- a/packages/form-render/src/widgets/fields/html/index.tsx
+++ b/packages/form-render/src/widgets/fields/html/index.tsx
@@ -1,11 +1,12 @@
-import React from 'react';
 import { Image } from 'antd';
+import React from 'react';
 
-export default function html({ value, options, schema = {} } : any) {
+export default function html({ value, checked, options, schema = {} } : any) {
+  console.log('value, checked: ', value, checked);
   let __html = '-';
-  
+
   if (schema.type === 'boolean') {
-    __html = value === true ? '✔' : '✘';
+    __html = checked === true || value===true ? '✔' : '✘';
   } else if (options?.length > 0) {
     if (['string', 'number'].indexOf(typeof value) > -1) {
       const item = options.find(item => item.value === value);


### PR DESCRIPTION
<img width="420" alt="image" src="https://github.com/alibaba/x-render/assets/26488273/5a4d5b37-1ff8-4b65-aa0e-c0fc1d06ede3">
<img width="528" alt="image" src="https://github.com/alibaba/x-render/assets/26488273/e3b3e3e8-4bbf-4296-a2d1-e27ca436ce58">

这两个组件在readOnly时一直都是展示✘。

![image](https://github.com/alibaba/x-render/assets/26488273/bf5f1696-5c2b-4b19-92fb-080f9b562051)

改了这里后可以正常展示