### PR TITLE
fix: fix form-render labelCol typo

### DIFF
--- a/packages/form-render/src/type.ts
+++ b/packages/form-render/src/type.ts
@@ -314,6 +314,7 @@ export interface FRProps extends Omit<AntdFormProps, 'form'> {
    * label 标签的文本对齐方式
    */
   labelAlign?: 'right' | 'left';
+  labelCol?: number | ColProps;
   fieldCol?: number | ColProps;
   /**
    *  只读模式


### PR DESCRIPTION
修复form-render的labelCol类型错误：
现有的form-render的labelCol是直接继承的antd form的labelCol类型
![CleanShot 2024-06-19 at 11 48 41@2x](https://github.com/alibaba/x-render/assets/52448921/6e24c235-cd7a-4858-bcfc-d2de56035ecb)
但是form-render是可以接受number类型并在getFormListLayout进行处理
![CleanShot 2024-06-19 at 11 50 16@2x](https://github.com/alibaba/x-render/assets/52448921/6c5e2966-3e0b-4416-ae73-69386148e4c2)
在文档的示例中也都是传入number，需要修复类型
