### PR TITLE
getFieldName处理数组时的逻辑问题修复

### DIFF
--- a/packages/form-render/src/models/useForm.ts
+++ b/packages/form-render/src/models/useForm.ts
@@ -50,14 +50,14 @@ const getFieldName = (_path: any): any => {
         return ite;
       });
     });
+  } else {
+    result = _path.split('.').map((item: any) => {
+      if (!isNaN(Number(item))) {
+        return item * 1;
+      }
+      return item;
+    });
   }
-
-  result = _path.split('.').map((item: any) => {
-    if (!isNaN(Number(item))) {
-      return item * 1;
-    }
-    return item;
-  });
 
   result = result.map(item => {
     if (typeof item === 'string' && item?.indexOf('[') === 0  && item?.indexOf(']') === item?.length -1) {


### PR DESCRIPTION
使用getValues试图获取多个字段值的时候，需要传入一个NamePathList，但是其中调用到getFieldName时，已经通过if(Array.is)处理过的_path，会再次被当做普通字符串通过split处理一遍，这是个明显的bug———入参_path正常情况下，不可能既支持map方法又支持split方法。