### PR TITLE
feat(x-flow): expose connectionLineComponent prop

### DIFF
--- a/packages/x-flow/src/XFlow.tsx
+++ b/packages/x-flow/src/XFlow.tsx
@@ -88,7 +88,7 @@ const XFlow: FC<FlowProps> = memo(props => {
   const { settingMap, globalConfig, readOnly } = useContext(ConfigContext);
   const [openPanel, setOpenPanel] = useState<boolean>(true);
   const [openLogPanel, setOpenLogPanel] = useState<boolean>(true);
-  const { onNodeClick, onEdgeClick, zoomOnScroll = true, panOnScroll = false, preventScrolling = true } = props;
+  const { onNodeClick, onEdgeClick, zoomOnScroll = true, panOnScroll = false, preventScrolling = true, connectionLineComponent } = props;
   const nodeEditorRef = useRef(null);
   const { copyNode, pasteNodeSimple } = useFlow();
   const { undo, redo } = useTemporalStore();
@@ -336,6 +336,7 @@ const XFlow: FC<FlowProps> = memo(props => {
         zoomOnScroll={zoomOnScroll}
         panOnScroll={panOnScroll} // 禁用滚动平移
         preventScrolling={preventScrolling} // 允许页面滚动
+        connectionLineComponent={connectionLineComponent}
         defaultEdgeOptions={{
           type: 'buttonedge',
           style: {

--- a/packages/x-flow/src/types.ts
+++ b/packages/x-flow/src/types.ts
@@ -187,6 +187,7 @@ export interface FlowProps {
   panOnScroll?: boolean;
   preventScrolling?: boolean;
   openColorfulMode?: boolean; // 是否开启多彩模式
+  connectionLineComponent?: ReactFlowProps['connectionLineComponent']; // 透传给 ReactFlow，用于自定义连线渲染
 }
 interface ItemInfo {
   key: 'copy' | 'paste' | 'delete' | string;


### PR DESCRIPTION
变动背景：
React Flow 包含 connectionLineComponent 可选 Prop，用于覆写默认连线渲染。XFlow 目前未向上暴露该 Prop，导致无法在不修改源码的情况下自定义连线样式。

改动点：类型补充、组件透传