### PR TITLE
fix:修复 antd-mobile的ConfigProvider因为不支持form属性导致传递的validateMessages属性失效

### DIFF
--- a/packages/form-render-mobile/src/form-core/index.tsx
+++ b/packages/form-render-mobile/src/form-core/index.tsx
@@ -51,6 +51,7 @@ const FormCore = (props: any) => {
     logOnSubmit,
     className,
     id,
+    validateMessages,
   } = transformProps({ ...props, ...schemaProps });
 
   useEffect(() => {
@@ -117,7 +118,7 @@ const FormCore = (props: any) => {
     if (!isFunction(logOnSubmit)) {
       return;
     }
-   
+
     const start = getSessionItem('FORM_START');
     const mount = getSessionItem('FORM_MOUNT_TIME');
 
@@ -190,6 +191,7 @@ const FormCore = (props: any) => {
       onFinish={handleFinish}
       onFinishFailed={handleFinishFailed}
       onValuesChange={handleValuesChange}
+      validateMessages={validateMessages}
     >
       <Grid columns={1}>
         <RenderCore schema={schema} />

--- a/packages/form-render-mobile/src/withProvider.tsx
+++ b/packages/form-render-mobile/src/withProvider.tsx
@@ -71,16 +71,17 @@ export default function withProvider<T>(Element: React.ComponentType<T>): React.
       <ConfigProvider
         {...configProvider}
         locale={langPack}
-        form={{
-          validateMessages: {
-            ...formValidateMessages,
-            ...validateMessages
-          }
-        }}
       >
         <ConfigContext.Provider value={configContext}>
           <FRContext.Provider value={store}>
-            <Element form={form} {...otherProps} />
+            <Element
+              form={form}
+              validateMessages={{
+                ...formValidateMessages,
+                ...validateMessages
+              }}
+              {...otherProps}
+            />
           </FRContext.Provider>
         </ConfigContext.Provider>
       </ConfigProvider>


### PR DESCRIPTION
##  修复描述

antd-mobile的ConfigProvider因为不支持form属性导致传递的validateMessages属性未在antd-mobile的Form中生效，现在改为直接传递该属性

## 截图说明

### 修改之前

<img width="1384" height="760" alt="image" src="https://github.com/user-attachments/assets/63bb0864-1cf8-4c37-a62d-ea81d0c61154" />

### 修改之后

<img width="1402" height="757" alt="image" src="https://github.com/user-attachments/assets/b358f858-c503-42a4-81b8-ea9034f976a2" />
