### PR TITLE
fix: add support for custom span in custom widget

### DIFF
--- a/packages/form-render/src/render-core/FieldItem/main.tsx
+++ b/packages/form-render/src/render-core/FieldItem/main.tsx
@@ -131,7 +131,7 @@ export default (props: any) => {
           exist: true,
         }}
       >
-        {inlineSelf ? content : <Col span={24} className={classnames('fr-obj-col', { [schema.className] : !!schema.className })}>{content}</Col>}
+        {inlineSelf ? content : <Col span={schema?.span || 24} className={classnames('fr-obj-col', { [schema.className] : !!schema.className })}>{content}</Col>}
       </UpperContext.Provider>
     );
   }


### PR DESCRIPTION
This PR addresses an issue where custom widgets always **occupy the full width** of the container. It adds functionality to **customize the widget's width**.